### PR TITLE
Delayed value conversion

### DIFF
--- a/vm/src/cons.rs
+++ b/vm/src/cons.rs
@@ -30,7 +30,7 @@ impl Cons {
     }
 
     pub const fn set_tag(self, tag: u8) -> Self {
-        Self(self.0 & !TAG_MASK | tag as u64 & TAG_MASK)
+        Self(self.0 & !(TAG_MASK << 1) | ((tag as u64 & TAG_MASK) << 1))
     }
 
     pub const fn from_raw(raw: u64) -> Self {

--- a/vm/src/cons.rs
+++ b/vm/src/cons.rs
@@ -26,7 +26,7 @@ impl Cons {
     }
 
     pub const fn tag(self) -> u8 {
-        (self.0 & TAG_MASK) as u8
+        ((self.0 >> 1) & TAG_MASK) as u8
     }
 
     pub const fn set_tag(self, tag: u8) -> Self {

--- a/vm/src/cons.rs
+++ b/vm/src/cons.rs
@@ -14,7 +14,7 @@ pub struct Cons(u64);
 
 impl Cons {
     pub const fn new(index: u64) -> Self {
-        Self(index << TAG_SIZE)
+        Self(index << (TAG_SIZE + 1))
     }
 
     pub const fn dummy(index: u64) -> Self {
@@ -22,7 +22,7 @@ impl Cons {
     }
 
     pub const fn index(self) -> usize {
-        (self.0 >> TAG_SIZE) as usize
+        (self.0 >> (TAG_SIZE + 1)) as usize
     }
 
     pub const fn tag(self) -> u8 {

--- a/vm/src/cons.rs
+++ b/vm/src/cons.rs
@@ -30,7 +30,7 @@ impl Cons {
     }
 
     pub const fn set_tag(self, tag: u8) -> Self {
-        Self(self.0 & !(TAG_MASK << 1) | ((tag as u64 & TAG_MASK) << 1))
+        Self(((self.0 >> 1) & !TAG_MASK | (tag as u64 & TAG_MASK)) << 1)
     }
 
     pub const fn from_raw(raw: u64) -> Self {

--- a/vm/src/cons.rs
+++ b/vm/src/cons.rs
@@ -17,7 +17,7 @@ impl Cons {
         Self(index << (TAG_SIZE + 1))
     }
 
-    pub const fn dummy(index: u64) -> Self {
+    pub(crate) const fn dummy(index: u64) -> Self {
         Self::new(u64::MAX - index)
     }
 
@@ -33,11 +33,11 @@ impl Cons {
         Self(((self.0 >> 1) & !TAG_MASK | (tag as u64 & TAG_MASK)) << 1)
     }
 
-    pub const fn from_raw(raw: u64) -> Self {
+    pub(crate) const fn from_raw(raw: u64) -> Self {
         Self(raw)
     }
 
-    pub const fn to_raw(self) -> u64 {
+    pub(crate) const fn to_raw(self) -> u64 {
         self.0
     }
 }

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -2,19 +2,23 @@ use crate::{value::Value, Error};
 use core::fmt::{self, Display, Formatter};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Number(i64);
+pub struct Number(u64);
 
 impl Number {
     pub const fn new(number: i64) -> Self {
-        Self(number)
+        Self(number as u64)
     }
 
     pub const fn to_i64(self) -> i64 {
-        self.0
+        self.0 as i64 >> 1
+    }
+
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
     }
 
     pub const fn to_raw(self) -> u64 {
-        self.0 as u64
+        self.0
     }
 }
 

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -32,7 +32,7 @@ impl TryFrom<Value> for Number {
 
 impl Display for Number {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "n{}", self.0)
+        write!(formatter, "n{}", self.0 >> 1)
     }
 }
 

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -35,3 +35,15 @@ impl Display for Number {
         write!(formatter, "n{}", self.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_i64() {
+        assert_eq!(Number::new(0).to_i64(), 0);
+        assert_eq!(Number::new(42).to_i64(), 42);
+        assert_eq!(Number::new(-1).to_i64(), -1);
+    }
+}

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -32,18 +32,25 @@ impl TryFrom<Value> for Number {
 
 impl Display for Number {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "n{}", self.0 >> 1)
+        write!(formatter, "n{}", self.to_i64())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::format;
 
     #[test]
     fn to_i64() {
         assert_eq!(Number::new(0).to_i64(), 0);
         assert_eq!(Number::new(42).to_i64(), 42);
         assert_eq!(Number::new(-1).to_i64(), -1);
+    }
+
+    #[test]
+    fn format() {
+        assert_eq!(format!("{}", Number::new(42)), "n42");
+        assert_eq!(format!("{}", Number::new(-1)), "n-1");
     }
 }

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -6,7 +6,7 @@ pub struct Number(u64);
 
 impl Number {
     pub const fn new(number: i64) -> Self {
-        Self(number as u64)
+        Self(((number << 1) | 1) as u64)
     }
 
     pub const fn to_i64(self) -> i64 {

--- a/vm/src/number.rs
+++ b/vm/src/number.rs
@@ -13,11 +13,11 @@ impl Number {
         self.0 as i64 >> 1
     }
 
-    pub const fn from_raw(raw: u64) -> Self {
+    pub(crate) const fn from_raw(raw: u64) -> Self {
         Self(raw)
     }
 
-    pub const fn to_raw(self) -> u64 {
+    pub(crate) const fn to_raw(self) -> u64 {
         self.0
     }
 }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -48,7 +48,7 @@ impl Value {
     }
 
     pub const fn is_cons(&self) -> bool {
-        self.0 & 0b1 == 0
+        self.0 & 1 == 0
     }
 
     pub const fn is_number(&self) -> bool {
@@ -58,13 +58,13 @@ impl Value {
 
 impl From<Cons> for Value {
     fn from(cons: Cons) -> Self {
-        Self(cons.to_raw() << 1)
+        Self(cons.to_raw())
     }
 }
 
 impl From<Number> for Value {
     fn from(number: Number) -> Self {
-        Self((number.to_raw() << 1) | 0b1)
+        Self(number.to_raw())
     }
 }
 

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -44,7 +44,7 @@ impl Value {
     pub const fn assume_number(self) -> Number {
         debug_assert!(self.is_number());
 
-        Number::new(self.0)
+        Number::from_raw(self.0)
     }
 
     pub const fn is_cons(&self) -> bool {

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -38,13 +38,13 @@ impl Value {
     pub const fn assume_cons(self) -> Cons {
         debug_assert!(self.is_cons());
 
-        Cons::from_raw(self.to_payload())
+        Cons::from_raw(self.0)
     }
 
     pub const fn assume_number(self) -> Number {
         debug_assert!(self.is_number());
 
-        Number::new(self.to_payload() as i64)
+        Number::new(self.0)
     }
 
     pub const fn is_cons(&self) -> bool {
@@ -53,10 +53,6 @@ impl Value {
 
     pub const fn is_number(&self) -> bool {
         !self.is_cons()
-    }
-
-    const fn to_payload(self) -> u64 {
-        ((self.0 as i64) >> 1) as u64
     }
 }
 

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -35,13 +35,13 @@ impl Value {
         }
     }
 
-    pub const fn assume_cons(self) -> Cons {
+    pub(crate) const fn assume_cons(self) -> Cons {
         debug_assert!(self.is_cons());
 
         Cons::from_raw(self.0)
     }
 
-    pub const fn assume_number(self) -> Number {
+    pub(crate) const fn assume_number(self) -> Number {
         debug_assert!(self.is_number());
 
         Number::from_raw(self.0)


### PR DESCRIPTION
Before: 

```sh
+ hyperfine --sort command 'target/release/stak bench/fibonacci/main.out' 'gsi bench/fibonacci/main.scm' 'python3 bench/fibonacci/main.py' 'csi -s bench/fibonacci/main.scm'
Benchmark 1: target/release/stak bench/fibonacci/main.out
  Time (mean ± σ):     12.780 s ±  0.316 s    [User: 12.662 s, System: 0.029 s]
  Range (min … max):   12.639 s … 13.668 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (13.668 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: gsi bench/fibonacci/main.scm
  Time (mean ± σ):     10.605 s ±  0.064 s    [User: 10.566 s, System: 0.035 s]
  Range (min … max):   10.565 s … 10.786 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 3: python3 bench/fibonacci/main.py
  Time (mean ± σ):      4.077 s ±  0.016 s    [User: 4.064 s, System: 0.011 s]
  Range (min … max):    4.060 s …  4.104 s    10 runs

Benchmark 4: csi -s bench/fibonacci/main.scm
  Time (mean ± σ):     21.159 s ±  0.380 s    [User: 20.962 s, System: 0.176 s]
  Range (min … max):   20.654 s … 21.743 s    10 runs

Relative speed comparison
        3.13 ±  0.08  target/release/stak bench/fibonacci/main.out
        2.60 ±  0.02  gsi bench/fibonacci/main.scm
        1.00          python3 bench/fibonacci/main.py
        5.19 ±  0.10  csi -s bench/fibonacci/main.scm
+ for file in '$(find bench -type f -name '\''*.scm'\'' | sort)'
+ base=bench/sum/main
+ cat prelude.scm bench/sum/main.scm
+ ./main.scm
+ hyperfine --sort command 'target/release/stak bench/sum/main.out' 'gsi bench/sum/main.scm' 'python3 bench/sum/main.py' 'csi -s bench/sum/main.scm'
Benchmark 1: target/release/stak bench/sum/main.out
  Time (mean ± σ):      9.989 s ±  0.032 s    [User: 9.956 s, System: 0.030 s]
  Range (min … max):    9.960 s … 10.066 s    10 runs

Benchmark 2: gsi bench/sum/main.scm
  Time (mean ± σ):      9.112 s ±  0.046 s    [User: 9.062 s, System: 0.038 s]
  Range (min … max):    9.057 s …  9.169 s    10 runs

Benchmark 3: python3 bench/sum/main.py
  Time (mean ± σ):      2.427 s ±  0.031 s    [User: 2.413 s, System: 0.013 s]
  Range (min … max):    2.388 s …  2.470 s    10 runs

Benchmark 4: csi -s bench/sum/main.scm
  Time (mean ± σ):     19.684 s ±  0.149 s    [User: 19.524 s, System: 0.157 s]
  Range (min … max):   19.351 s … 19.846 s    10 runs

Relative speed comparison
        4.12 ±  0.05  target/release/stak bench/sum/main.out
        3.75 ±  0.05  gsi bench/sum/main.scm
        1.00          python3 bench/sum/main.py
        8.11 ±  0.12  csi -s bench/sum/main.scm
+ for file in '$(find bench -type f -name '\''*.scm'\'' | sort)'
+ base=bench/tak/main
+ cat prelude.scm bench/tak/main.scm
+ ./main.scm
+ hyperfine --sort command 'target/release/stak bench/tak/main.out' 'gsi bench/tak/main.scm' 'python3 bench/tak/main.py' 'csi -s bench/tak/main.scm'
Benchmark 1: target/release/stak bench/tak/main.out
  Time (mean ± σ):      5.238 s ±  0.008 s    [User: 5.223 s, System: 0.014 s]
  Range (min … max):    5.227 s …  5.248 s    10 runs

Benchmark 2: gsi bench/tak/main.scm
  Time (mean ± σ):      3.886 s ±  0.022 s    [User: 3.866 s, System: 0.018 s]
  Range (min … max):    3.868 s …  3.929 s    10 runs

Benchmark 3: python3 bench/tak/main.py
  Time (mean ± σ):      1.479 s ±  0.024 s    [User: 1.470 s, System: 0.008 s]
  Range (min … max):    1.453 s …  1.533 s    10 runs

Benchmark 4: csi -s bench/tak/main.scm
  Time (mean ± σ):      7.727 s ±  0.160 s    [User: 7.647 s, System: 0.078 s]
  Range (min … max):    7.515 s …  7.975 s    10 runs

Relative speed comparison
        3.54 ±  0.06  target/release/stak bench/tak/main.out
        2.63 ±  0.04  gsi bench/tak/main.scm
        1.00          python3 bench/tak/main.py
        5.22 ±  0.14  csi -s bench/tak/main.scm
```

After:

```sh
+ hyperfine --sort command 'target/release/stak bench/fibonacci/main.out' 'gsi bench/fibonacci/main.scm' 'python3 bench/fibonacci/main.py' 'csi -s bench/fibonacci/main.scm'
Benchmark 1: target/release/stak bench/fibonacci/main.out
  Time (mean ± σ):     11.814 s ±  0.371 s    [User: 11.665 s, System: 0.037 s]
  Range (min … max):   11.656 s … 12.848 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (12.848 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: gsi bench/fibonacci/main.scm
  Time (mean ± σ):     10.611 s ±  0.057 s    [User: 10.566 s, System: 0.041 s]
  Range (min … max):   10.563 s … 10.762 s    10 runs

Benchmark 3: python3 bench/fibonacci/main.py
  Time (mean ± σ):      4.097 s ±  0.027 s    [User: 4.080 s, System: 0.014 s]
  Range (min … max):    4.069 s …  4.149 s    10 runs

Benchmark 4: csi -s bench/fibonacci/main.scm
  Time (mean ± σ):     21.125 s ±  0.330 s    [User: 20.938 s, System: 0.169 s]
  Range (min … max):   20.642 s … 21.633 s    10 runs

Relative speed comparison
        2.88 ±  0.09  target/release/stak bench/fibonacci/main.out
        2.59 ±  0.02  gsi bench/fibonacci/main.scm
        1.00          python3 bench/fibonacci/main.py
        5.16 ±  0.09  csi -s bench/fibonacci/main.scm
+ for file in '$(find bench -type f -name '\''*.scm'\'' | sort)'
+ base=bench/sum/main
+ cat prelude.scm bench/sum/main.scm
+ ./main.scm
+ hyperfine --sort command 'target/release/stak bench/sum/main.out' 'gsi bench/sum/main.scm' 'python3 bench/sum/main.py' 'csi -s bench/sum/main.scm'
Benchmark 1: target/release/stak bench/sum/main.out
  Time (mean ± σ):      9.240 s ±  0.093 s    [User: 9.214 s, System: 0.020 s]
  Range (min … max):    9.191 s …  9.494 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (9.494 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: gsi bench/sum/main.scm
  Time (mean ± σ):      9.091 s ±  0.042 s    [User: 9.052 s, System: 0.030 s]
  Range (min … max):    9.053 s …  9.172 s    10 runs

Benchmark 3: python3 bench/sum/main.py
  Time (mean ± σ):      2.378 s ±  0.030 s    [User: 2.363 s, System: 0.012 s]
  Range (min … max):    2.338 s …  2.440 s    10 runs

Benchmark 4: csi -s bench/sum/main.scm
  Time (mean ± σ):     19.683 s ±  0.167 s    [User: 19.515 s, System: 0.163 s]
  Range (min … max):   19.254 s … 19.859 s    10 runs

Relative speed comparison
        3.89 ±  0.06  target/release/stak bench/sum/main.out
        3.82 ±  0.05  gsi bench/sum/main.scm
        1.00          python3 bench/sum/main.py
        8.28 ±  0.13  csi -s bench/sum/main.scm
+ for file in '$(find bench -type f -name '\''*.scm'\'' | sort)'
+ base=bench/tak/main
+ cat prelude.scm bench/tak/main.scm
+ ./main.scm
+ hyperfine --sort command 'target/release/stak bench/tak/main.out' 'gsi bench/tak/main.scm' 'python3 bench/tak/main.py' 'csi -s bench/tak/main.scm'
Benchmark 1: target/release/stak bench/tak/main.out
  Time (mean ± σ):      4.753 s ±  0.074 s    [User: 4.742 s, System: 0.010 s]
  Range (min … max):    4.690 s …  4.867 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (4.867 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: gsi bench/tak/main.scm
  Time (mean ± σ):      3.872 s ±  0.007 s    [User: 3.854 s, System: 0.016 s]
  Range (min … max):    3.860 s …  3.881 s    10 runs

Benchmark 3: python3 bench/tak/main.py
  Time (mean ± σ):      1.455 s ±  0.011 s    [User: 1.447 s, System: 0.006 s]
  Range (min … max):    1.437 s …  1.470 s    10 runs

Benchmark 4: csi -s bench/tak/main.scm
  Time (mean ± σ):      7.797 s ±  0.093 s    [User: 7.732 s, System: 0.064 s]
  Range (min … max):    7.652 s …  7.963 s    10 runs

Relative speed comparison
        3.27 ±  0.06  target/release/stak bench/tak/main.out
        2.66 ±  0.02  gsi bench/tak/main.scm
        1.00          python3 bench/tak/main.py
        5.36 ±  0.08  csi -s bench/tak/main.scm
```