### PR TITLE
Optimize pritimive symbol names

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -62,8 +62,8 @@
 
 (define primitives
   '(
-    (cons 1)
-    (close 2)
+    ($$cons 1)
+    ($$close 2)
     ($$- 13)))
 
 ; Types
@@ -764,7 +764,7 @@
                     (cddr expression)
                     '()))
                 '())
-              (compile-primitive-call 'close continuation))))
+              (compile-primitive-call '$$close continuation))))
 
         (($$quote)
           (compile-constant (cadr expression) continuation))
@@ -837,7 +837,7 @@
         cdr
         (lambda ()
           (if (eqv? tag pair-type)
-            (compile-primitive-call 'cons (continue))
+            (compile-primitive-call '$$cons (continue))
             (rib
               constant-instruction
               tag

--- a/compile.scm
+++ b/compile.scm
@@ -639,10 +639,10 @@
     call-instruction
     (rib-cons
       (case name
-        ((close)
+        (($$close)
           1)
 
-        ((cons $$-)
+        (($$cons $$-)
           2)
 
         (($$rib)


### PR DESCRIPTION
Close #361.

This change makes more symbols to be considered as internal (empty) symbols.