### PR TITLE
`continue` instruction encoding

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,9 @@ jobs:
           - name: stak
             host: guile
           - name: stak
-            features: [gc_always]
+            features:
+              [gc_always]
+              # TODO Can we remove this special field?
             tags: not @long
           - name: chibi
           - name: gauche

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,7 @@ jobs:
             host: guile
           - name: stak
             features: [gc_always]
+            tags: not @long
           - name: chibi
           - name: gauche
           - name: guile
@@ -71,7 +72,7 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: ruby/setup-ruby@v1
       - run: brew install chibi-scheme gauche guile
-      - run: tools/integration_test.sh --tags 'not @stak or @${{ matrix.interpreter.name }}'
+      - run: tools/integration_test.sh --tags '(not @stak or @${{ matrix.interpreter.name }}) and ${{ matrix.interpreter.tags || 'not @any' }}'
   test:
     needs:
       - build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,9 +57,8 @@ jobs:
           - name: stak
             host: guile
           - name: stak
-            features:
-              [gc_always]
-              # TODO Can we remove this special field?
+            features: [gc_always]
+            # TODO Can we remove this special field?
             tags: not @long
           - name: chibi
           - name: gauche

--- a/code/src/decode/decoder.rs
+++ b/code/src/decode/decoder.rs
@@ -87,6 +87,7 @@ impl<'a> Decoder<'a> {
                     ),
                 ),
                 Instruction::SKIP => Instruction::Skip(integer),
+                Instruction::NOP => Instruction::Nop(integer),
                 _ => return Err(Error::IllegalInstruction),
             };
 

--- a/code/src/encode.rs
+++ b/code/src/encode.rs
@@ -73,6 +73,9 @@ fn encode_instructions(codes: &mut Vec<u8>, instructions: &[Instruction]) {
                 encode_instructions(codes, body);
             }
             Instruction::Skip(count) => encode_instruction(codes, Instruction::SKIP, *count, true),
+            Instruction::Nop(operand) => {
+                encode_instruction(codes, Instruction::NOP, *operand, r#return)
+            }
         }
     }
 }

--- a/code/src/ir/instruction.rs
+++ b/code/src/ir/instruction.rs
@@ -14,6 +14,7 @@ pub enum Instruction {
     #[cfg(feature = "alloc")]
     Closure(u64, Vec<Instruction>),
     Skip(u64),
+    Nop(u64),
 }
 
 impl Instruction {
@@ -24,6 +25,7 @@ impl Instruction {
     pub const IF: u8 = 4;
     pub const CLOSURE: u8 = 5;
     pub const SKIP: u8 = 6;
+    pub const NOP: u8 = 7;
 }
 
 pub(crate) struct DisplayInstruction<'a> {
@@ -70,6 +72,7 @@ impl<'a> Display for DisplayInstruction<'a> {
                 )
             }
             Instruction::Skip(count) => write!(formatter, "skip {}", count),
+            Instruction::Nop(operand) => write!(formatter, "nop {}", operand),
         }
     }
 }

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -2,6 +2,8 @@ use device::StdioDevice;
 use std::{env::args, error::Error, fs::read, process::exit};
 use vm::{Number, Vm};
 
+// TODO Change this value through an environment variable.
+// TODO Make a default value `1 << 17`.
 const HEAP_SIZE: usize = 1 << 22;
 
 fn main() {

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -4,7 +4,7 @@ use vm::{Number, Vm};
 
 // TODO Change this value through an environment variable.
 // TODO Make a default value `1 << 17`.
-const HEAP_SIZE: usize = 1 << 22;
+const HEAP_SIZE: usize = 1 << 20;
 
 fn main() {
     if let Err(error) = run() {

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -2,7 +2,7 @@ use device::StdioDevice;
 use std::{env::args, error::Error, fs::read, process::exit};
 use vm::{Number, Vm};
 
-const HEAP_SIZE: usize = 1 << 17;
+const HEAP_SIZE: usize = 1 << 22;
 
 fn main() {
     if let Err(error) = run() {
@@ -12,7 +12,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    let mut heap = [Number::new(0).into(); HEAP_SIZE];
+    let mut heap = vec![Number::new(0).into(); HEAP_SIZE];
     let mut vm = Vm::<StdioDevice>::new(&mut heap, Default::default());
 
     vm.initialize(read(args().nth(1).ok_or(format!(

--- a/compile.scm
+++ b/compile.scm
@@ -1116,7 +1116,7 @@
         codes
         terminal
         (cond
-          ((memv instruction (list set-instruction get-instruction))
+          ((memv instruction (list set-instruction get-instruction continue-instruction))
             (encode-simple instruction))
 
           ((eqv? instruction call-instruction)
@@ -1153,9 +1153,6 @@
               (if (null? continuation)
                 target
                 (encode-instruction skip-instruction (count-skips codes continuation) #t target))))
-
-          ((eqv? instruction continue-instruction)
-            (encode-simple continue-instruction))
 
           (else
             (error "invalid instruction" instruction)))))))

--- a/compile.scm
+++ b/compile.scm
@@ -46,7 +46,7 @@
 ; Only for encoding
 (define closure-instruction 5)
 (define skip-instruction 6)
-(define continue-instruction 7)
+(define nop-instruction 7)
 
 ; Primitives
 
@@ -744,7 +744,7 @@
             (cadr expression)
             (rib
               if-instruction
-              (compile-expression context (caddr expression) (rib continue-instruction 0 continuation))
+              (compile-expression context (caddr expression) (rib nop-instruction 0 continuation))
               (compile-expression context (cadddr expression) continuation))))
 
         (($$lambda)
@@ -963,7 +963,7 @@
               symbols)))))))
 
 (define (terminal-codes? codes)
-  (or (null? codes) (eqv? (rib-tag codes) continue-instruction)))
+  (or (null? codes) (eqv? (rib-tag codes) nop-instruction)))
 
 (define (find-continuation codes)
   (cond
@@ -1116,7 +1116,7 @@
         codes
         terminal
         (cond
-          ((memv instruction (list set-instruction get-instruction continue-instruction))
+          ((memv instruction (list set-instruction get-instruction nop-instruction))
             (encode-simple instruction))
 
           ((eqv? instruction call-instruction)

--- a/compile.scm
+++ b/compile.scm
@@ -1098,8 +1098,8 @@
     (let* (
         (instruction (rib-tag codes))
         (operand (rib-car codes))
-        (rest (rib-cdr codes))
-        (return (null? rest))
+        (codes (rib-cdr codes))
+        (return (null? codes))
         (encode-simple
           (lambda (instruction)
             (encode-instruction
@@ -1109,7 +1109,7 @@
               target))))
       (encode-codes
         context
-        rest
+        codes
         terminal
         (cond
           ((memv instruction (list set-instruction get-instruction))
@@ -1148,7 +1148,7 @@
                     (encode-instruction if-instruction 0 #f target))))
               (if (null? continuation)
                 target
-                (encode-instruction skip-instruction (count-skips rest continuation) #t target))))
+                (encode-instruction skip-instruction (count-skips codes continuation) #t target))))
 
           ((eqv? instruction continue-instruction)
             (encode-simple continue-instruction))

--- a/compile.scm
+++ b/compile.scm
@@ -1152,7 +1152,7 @@
                   (encode-simple constant-instruction))))
 
             ((eqv? instruction if-instruction)
-              (let* (
+              (let (
                   (continuation (find-continuation operand))
                   (target
                     (encode-codes

--- a/compile.scm
+++ b/compile.scm
@@ -1068,6 +1068,7 @@
     (encode-codes
       context
       (rib-cdr code)
+      '()
       (encode-instruction
         closure-instruction
         (rib-car code)
@@ -1091,8 +1092,8 @@
 (define (terminal-codes? codes)
   (or (null? codes) (eqv? (rib-tag codes) continue-instruction)))
 
-(define (encode-codes context codes target)
-  (if (terminal-codes? codes)
+(define (encode-codes context codes terminal target)
+  (if (eq? codes terminal)
     target
     (let* (
         (instruction (rib-tag codes))
@@ -1109,6 +1110,7 @@
       (encode-codes
         context
         rest
+        terminal
         (cond
           ((memv instruction (list set-instruction get-instruction))
             (encode-simple instruction))
@@ -1142,6 +1144,7 @@
                   (encode-codes
                     context
                     operand
+                    continuation
                     (encode-instruction if-instruction 0 #f target))))
               (if (null? continuation)
                 target
@@ -1190,6 +1193,7 @@
           (append (map cdr default-constants) (list rib-symbol) symbols)
           constant-context)
         codes
+        '()
         '()))))
 
 ; Main

--- a/compile.scm
+++ b/compile.scm
@@ -962,6 +962,9 @@
             (else
               symbols)))))))
 
+(define (terminal-codes? codes)
+  (or (null? codes) (eqv? (rib-tag codes) continue-instruction)))
+
 (define (find-continuation codes)
   (if (terminal-codes? codes)
     (if (rib? codes)
@@ -1088,9 +1091,6 @@
 
     (else
       (error "invalid operand" operand))))
-
-(define (terminal-codes? codes)
-  (or (null? codes) (eqv? (rib-tag codes) continue-instruction)))
 
 (define (encode-codes context codes terminal target)
   (if (eq? codes terminal)

--- a/compile.scm
+++ b/compile.scm
@@ -755,7 +755,7 @@
             (cadr expression)
             (rib
               if-instruction
-              (compile-expression context (caddr expression) (rib continue-instruction #f continuation))
+              (compile-expression context (caddr expression) (rib continue-instruction 0 continuation))
               (compile-expression context (cadddr expression) continuation))))
 
         (($$lambda)
@@ -1160,7 +1160,7 @@
                 (encode-instruction skip-instruction (count-skips rest continuation) #t target))))
 
           ((eqv? instruction continue-instruction)
-            (encode-instruction continue-instruction 0 #f target))
+            (encode-simple continue-instruction))
 
           (else
             (error "invalid instruction" instruction)))))))

--- a/compile.scm
+++ b/compile.scm
@@ -962,15 +962,18 @@
             (else
               symbols)))))))
 
+(define (nop-codes? codes)
+  (and (rib? codes) (eqv? (rib-tag codes) nop-instruction)))
+
 (define (terminal-codes? codes)
-  (or (null? codes) (eqv? (rib-tag codes) nop-instruction)))
+  (or (null? codes) (nop-codes? codes)))
 
 (define (find-continuation codes)
   (cond
     ((null? codes)
       '())
 
-    ((terminal-codes? codes)
+    ((nop-codes? codes)
       (rib-cdr codes))
 
     (else

--- a/compile.scm
+++ b/compile.scm
@@ -966,11 +966,15 @@
   (or (null? codes) (eqv? (rib-tag codes) continue-instruction)))
 
 (define (find-continuation codes)
-  (if (terminal-codes? codes)
-    (if (rib? codes)
-      (rib-cdr codes)
-      codes)
-    (find-continuation (rib-cdr codes))))
+  (cond
+    ((null? codes)
+      '())
+
+    ((terminal-codes? codes)
+      (rib-cdr codes))
+
+    (else
+      (find-continuation (rib-cdr codes)))))
 
 (define (count-skips codes continuation)
   (let loop ((codes codes) (count 0))

--- a/compile.scm
+++ b/compile.scm
@@ -46,6 +46,7 @@
 ; Only for encoding
 (define closure-instruction 5)
 (define skip-instruction 6)
+(define continue-instruction 7)
 
 ; Primitives
 
@@ -752,8 +753,9 @@
           (compile-expression
             context
             (cadr expression)
-            (rib if-instruction
-              (compile-expression context (caddr expression) continuation)
+            (rib
+              if-instruction
+              (compile-expression context (caddr expression) (rib continue-instruction #f continuation))
               (compile-expression context (cadddr expression) continuation))))
 
         (($$lambda)
@@ -874,9 +876,11 @@
           (build-rib (char->integer constant) '() char-type))
 
         ((and (number? constant) (> 0 constant))
-          (rib constant-instruction
+          (rib
+            constant-instruction
             0
-            (rib constant-instruction
+            (rib
+              constant-instruction
               (abs constant)
               (compile-primitive-call '$$- (continue)))))
 
@@ -1154,6 +1158,9 @@
               (if (null? continuation)
                 target
                 (encode-instruction skip-instruction (count-skips rest continuation) #t target))))
+
+          ((eqv? instruction continue-instruction)
+            target)
 
           (else
             (error "invalid instruction" instruction)))))))

--- a/compile.scm
+++ b/compile.scm
@@ -1160,7 +1160,7 @@
                 (encode-instruction skip-instruction (count-skips rest continuation) #t target))))
 
           ((eqv? instruction continue-instruction)
-            target)
+            (encode-instruction continue-instruction 0 #f target))
 
           (else
             (error "invalid instruction" instruction)))))))

--- a/features/boolean.feature
+++ b/features/boolean.feature
@@ -53,3 +53,50 @@ Feature: Boolean
     """
     When I successfully run `scheme main.scm`
     Then the stdout should contain exactly "A"
+
+  Scenario Outline: Use deeply nested if expressions
+    Given a file named "main.scm" with:
+    """scheme
+    (import (scheme base))
+
+    (if <value1>
+      (begin
+        (write-u8 65)
+          (if <value2>
+            (begin
+              (write-u8 65)
+              (if <value3>
+                (write-u8 65)
+                (write-u8 66)))
+            (begin
+              (write-u8 66)
+              (if <value3>
+                (write-u8 65)
+                (write-u8 66)))))
+      (begin
+        (write-u8 66)
+          (if <value2>
+            (begin
+              (write-u8 65)
+              (if <value3>
+                (write-u8 65)
+                (write-u8 66)))
+            (begin
+              (write-u8 66)
+              (if <value3>
+                (write-u8 65)
+                (write-u8 66))))))
+    """
+    When I successfully run `scheme main.scm`
+    Then the stdout should contain exactly "<output>"
+
+    Examples:
+      | value1 | value2 | value3 | output |
+      | #t     | #t     | #t     | AAA    |
+      | #t     | #t     | #f     | AAB    |
+      | #t     | #f     | #t     | ABA    |
+      | #t     | #f     | #f     | ABB    |
+      | #f     | #t     | #t     | BAA    |
+      | #f     | #t     | #f     | BAB    |
+      | #f     | #f     | #t     | BBA    |
+      | #f     | #f     | #f     | BBB    |

--- a/features/macro.feature
+++ b/features/macro.feature
@@ -366,10 +366,7 @@ Feature: Macro
 
     (foo 42)
     """
-    When I run the following script:
-    """sh
-    compile.sh main.scm > main.out
-    """
+    When I run `scheme main.scm`
     Then the exit status should not be 0
 
   Scenario: Define a local macro

--- a/features/smoke.feature
+++ b/features/smoke.feature
@@ -60,20 +60,27 @@ Feature: Smoke
     Then the stdout should contain exactly "7B7A"
 
   @long
-  Scenario: Compile many conditionals
+  Scenario: Compile many sequential if expressions
     Given a file named "main.scm" with:
     """scheme
     (import (scheme base) (scheme write))
     """
-    And a file named "line.scm" with:
+    And a file named "foo.scm" with:
     """scheme
     (write-u8 (if #t (if #t 65 66) (if #t 67 68)))
     """
     And I run the following script:
     """sh
-    for _ in $(seq 10000); do
-      cat line.scm >> main.scm
+    for _ in $(seq 13); do
+      for _ in $(seq 2); do
+        cat foo.scm >> bar.scm
+      done
+
+      cp bar.scm foo.scm
+      rm bar.scm
     done
+
+    cat foo.scm >> main.scm
     """
     And the exit status should be 0
     When I successfully run `scheme main.scm`

--- a/features/smoke.feature
+++ b/features/smoke.feature
@@ -70,7 +70,7 @@ Feature: Smoke
     """
     And I run the following script:
     """sh
-    for _ in $(seq 1000); do
+    for _ in $(seq 10000); do
       cat line.scm >> main.scm
     done
     """

--- a/features/smoke.feature
+++ b/features/smoke.feature
@@ -59,6 +59,7 @@ Feature: Smoke
     When I successfully run `scheme main.scm`
     Then the stdout should contain exactly "7B7A"
 
+  @long
   Scenario: Compile many conditionals
     Given a file named "main.scm" with:
     """scheme

--- a/features/smoke.feature
+++ b/features/smoke.feature
@@ -58,3 +58,22 @@ Feature: Smoke
     """
     When I successfully run `scheme main.scm`
     Then the stdout should contain exactly "7B7A"
+
+  Scenario: Compile many conditionals
+    Given a file named "main.scm" with:
+    """scheme
+    (import (scheme base) (scheme write))
+    """
+    And a file named "line.scm" with:
+    """scheme
+    (write-u8 (if #t (if #t 65 66) (if #t 67 68)))
+    """
+    And I run the following script:
+    """sh
+    for _ in $(seq 1000); do
+      cat line.scm >> main.scm
+    done
+    """
+    And the exit status should be 0
+    When I successfully run `scheme main.scm`
+    Then the exit status should be 0

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,5 +1,5 @@
 require "aruba/cucumber"
 
 Aruba.configure do |config|
-  config.exit_timeout = 120
+  config.exit_timeout = 60
 end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,5 +1,5 @@
-require 'aruba/cucumber'
+require "aruba/cucumber"
 
 Aruba.configure do |config|
-  config.exit_timeout = 60
+  config.exit_timeout = 120
 end

--- a/tools/scheme/stak/scheme
+++ b/tools/scheme/stak/scheme
@@ -5,4 +5,5 @@ set -e
 directory=$(dirname $0)/../../..
 
 $directory/tools/compile.sh "$@" >main.out
+$directory/target/release/stak-decode main.out >/dev/null
 $directory/target/release/stak main.out

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -212,9 +212,7 @@ impl<'a, T: Device> Vm<'a, T> {
                     })
                     .assume_cons();
                 }
-                _ => {
-                    // Ignore an invalid instruction.
-                }
+                _ => return Err(Error::IllegalInstruction),
             }
 
             trace_heap!(self);

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -212,10 +212,11 @@ impl<'a, T: Device> Vm<'a, T> {
                     })
                     .assume_cons();
                 }
-                _ => {
+                code::Instruction::NOP => {
                     // Ignore an invalid instruction.
                     self.advance_program_counter()
                 }
+                _ => return Err(Error::IllegalInstruction),
             }
 
             trace_heap!(self);
@@ -749,7 +750,7 @@ impl<'a, T: Device> Vm<'a, T> {
                 code::Instruction::SET
                 | code::Instruction::GET
                 | code::Instruction::CONSTANT
-                | 7 => {
+                | code::Instruction::NOP => {
                     self.append_instruction(instruction, self.decode_operand(integer), r#return)?
                 }
                 code::Instruction::IF => {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -214,6 +214,7 @@ impl<'a, T: Device> Vm<'a, T> {
                 }
                 _ => {
                     // Ignore an invalid instruction.
+                    self.advance_program_counter()
                 }
             }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -746,7 +746,10 @@ impl<'a, T: Device> Vm<'a, T> {
                     )?;
                     self.append_instruction(instruction, operand.into(), r#return)?
                 }
-                code::Instruction::SET | code::Instruction::GET | code::Instruction::CONSTANT => {
+                code::Instruction::SET
+                | code::Instruction::GET
+                | code::Instruction::CONSTANT
+                | 7 => {
                     self.append_instruction(instruction, self.decode_operand(integer), r#return)?
                 }
                 code::Instruction::IF => {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -212,10 +212,7 @@ impl<'a, T: Device> Vm<'a, T> {
                     })
                     .assume_cons();
                 }
-                code::Instruction::NOP => {
-                    // Ignore an invalid instruction.
-                    self.advance_program_counter()
-                }
+                code::Instruction::NOP => self.advance_program_counter(),
                 _ => return Err(Error::IllegalInstruction),
             }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -212,7 +212,9 @@ impl<'a, T: Device> Vm<'a, T> {
                     })
                     .assume_cons();
                 }
-                _ => return Err(Error::IllegalInstruction),
+                _ => {
+                    // Ignore an invalid instruction.
+                }
             }
 
             trace_heap!(self);


### PR DESCRIPTION
Close #376.

# Todo 

- [ ] Refactor Cucumber tags on CI.
- [ ] Consider flags in rib tags instead of nop instructions.
- [ ] Refactor VM heap initialization in the `stak` command.