### PR TITLE
Do not include default symbols

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -996,7 +996,7 @@
           ((and
               (symbol? operand)
               (not (memv operand default-symbols))
-              (not (memq operand symbols)))
+              (not (memv operand symbols)))
             (cons operand symbols))
 
           (else

--- a/compile.scm
+++ b/compile.scm
@@ -30,12 +30,11 @@
   '(
     (#f . $$false)
     (#t . $$true)
-    (() . $$null)))
+    (() . $$null)
+    ; It is fine to have a key duplicate with `false`'s because it is never hit.
+    (#f . $$rib)))
 
-(define rib-symbol '$$rib)
-
-(define default-symbols
-  (append (map cdr default-constants) (list rib-symbol)))
+(define default-symbols (map cdr default-constants))
 
 ; Instructions
 
@@ -883,7 +882,7 @@
             (make-rib
               constant-instruction
               tag
-              (compile-primitive-call rib-symbol (continue)))))))))
+              (compile-primitive-call '$$rib (continue)))))))))
 
 (define (build-constant-codes context constant continue)
   (let (
@@ -1211,7 +1210,7 @@
       (make-rib constant-instruction
         procedure-type
         (compile-primitive-call
-          rib-symbol
+          '$$rib
           (make-rib set-instruction (car primitive) continuation))))))
 
 (define (build-primitives primitives continuation)

--- a/compile.scm
+++ b/compile.scm
@@ -32,6 +32,9 @@
     (#t . $$true)
     (() . $$null)))
 
+(define default-symbols
+  (append (map cdr default-constants) (list rib-symbol)))
+
 (define rib-symbol '$$rib)
 
 ; Instructions
@@ -993,8 +996,7 @@
 
           ((and
               (symbol? operand)
-              (not (memv operand (map cdr default-constants)))
-              (not (eqv? operand rib-symbol))
+              (not (memv operand default-symbols))
               (not (memq operand symbols)))
             (cons operand symbols))
 
@@ -1234,7 +1236,7 @@
       symbols
       (encode-codes
         (make-encode-context
-          (append (map cdr default-constants) (list rib-symbol) symbols)
+          (append default-symbols symbols)
           constant-context)
         codes
         '()))))

--- a/compile.scm
+++ b/compile.scm
@@ -993,6 +993,7 @@
 
           ((and
               (symbol? operand)
+              (not (memv operand (map cdr default-constants)))
               (not (eqv? operand rib-symbol))
               (not (memq operand symbols)))
             (cons operand symbols))

--- a/compile.scm
+++ b/compile.scm
@@ -32,10 +32,10 @@
     (#t . $$true)
     (() . $$null)))
 
+(define rib-symbol '$$rib)
+
 (define default-symbols
   (append (map cdr default-constants) (list rib-symbol)))
-
-(define rib-symbol '$$rib)
 
 ; Instructions
 


### PR DESCRIPTION
- Exclude default constants from symbols
- Refactor
