### PR TITLE
`code` and `data` primitives

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -68,7 +68,8 @@
   '(
     ($$cons 1)
     ($$close 2)
-    ($$- 13)))
+    ($$- 13)
+    ($$data 21)))
 
 ; Types
 
@@ -661,6 +662,9 @@
       (($$cons $$-)
         2)
 
+      (($$data)
+        3)
+
       (($$rib)
         4)
 
@@ -866,10 +870,7 @@
         car
         cdr
         (lambda ()
-          (code-rib
-            constant-instruction
-            0
-            (compile-primitive-call '$$rib (continue)))))))
+          (compile-primitive-call '$$data (continue))))))
 
   (let ((symbol (constant-context-constant context constant)))
     (if symbol

--- a/prelude.scm
+++ b/prelude.scm
@@ -390,6 +390,7 @@
 
 (define (primitive id) ($$rib procedure-type '() id 0))
 
+(define rib $$rib)
 (define cons (primitive 1))
 (define close (primitive 2))
 (define rib? (primitive 3))

--- a/prelude.scm
+++ b/prelude.scm
@@ -390,7 +390,6 @@
 
 (define (primitive id) ($$rib procedure-type '() id 0))
 
-(define rib $$rib)
 (define cons (primitive 1))
 (define close (primitive 2))
 (define rib? (primitive 3))
@@ -410,9 +409,8 @@
 (define $$write-u8 (primitive 17))
 (define $$write-error-u8 (primitive 18))
 (define $$halt (primitive 19))
-
-(define (data-rib type car cdr)
-  (rib type car cdr 0))
+(define code-rib (primitive 20))
+(define data-rib (primitive 21))
 
 (define (apply f xs)
   ($$apply f xs))
@@ -1577,8 +1575,6 @@
 ; Compiler utility
 
 ; TODO Move those to a compiler when `cond-expand` is implemented.
-(define (code-rib tag car cdr)
-  (rib pair-type car cdr tag))
 (define cons-rib cons)
 (define target-pair? pair?)
 (define target-procedure? procedure?)

--- a/primitive/src/small.rs
+++ b/primitive/src/small.rs
@@ -152,7 +152,7 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
             }
             Primitive::HALT => return Err(Error::Halt),
             Primitive::CODE => {
-                let [tag, car, cdr] = Self::pop_arguments::<3>(vm)?;
+                let [tag, car, cdr] = Self::pop_arguments::<3>(vm);
                 let rib = vm.allocate(
                     car.set_tag(Type::Pair as u8),
                     cdr.set_tag(tag.assume_number().to_i64() as u8),
@@ -160,7 +160,7 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
                 vm.set_top(rib.into());
             }
             Primitive::DATA => {
-                let [r#type, car, cdr] = Self::pop_arguments::<3>(vm)?;
+                let [r#type, car, cdr] = Self::pop_arguments::<3>(vm);
                 let rib = vm.allocate(car.set_tag(r#type.assume_number().to_i64() as u8), cdr)?;
                 vm.set_top(rib.into());
             }

--- a/primitive/src/small.rs
+++ b/primitive/src/small.rs
@@ -168,6 +168,19 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
                     .map_err(|_| Error::WriteError)?
             }
             Primitive::HALT => return Err(Error::Halt),
+            Primitive::CODE => {
+                let [car, cdr, tag] = Self::pop_arguments::<3>(vm)?;
+                let rib = vm.allocate(
+                    car.set_tag(Type::Pair as u8),
+                    cdr.set_tag(tag.assume_number().to_i64() as u8),
+                )?;
+                vm.set_top(rib.into());
+            }
+            Primitive::DATA => {
+                let [r#type, car, cdr] = Self::pop_arguments::<3>(vm)?;
+                let rib = vm.allocate(car.set_tag(r#type.assume_number().to_i64() as u8), cdr)?;
+                vm.set_top(rib.into());
+            }
             _ => return Err(Error::Illegal),
         }
 

--- a/primitive/src/small.rs
+++ b/primitive/src/small.rs
@@ -169,7 +169,7 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
             }
             Primitive::HALT => return Err(Error::Halt),
             Primitive::CODE => {
-                let [car, cdr, tag] = Self::pop_arguments::<3>(vm)?;
+                let [tag, car, cdr] = Self::pop_arguments::<3>(vm)?;
                 let rib = vm.allocate(
                     car.set_tag(Type::Pair as u8),
                     cdr.set_tag(tag.assume_number().to_i64() as u8),

--- a/primitive/src/small/primitive.rs
+++ b/primitive/src/small/primitive.rs
@@ -21,6 +21,8 @@ pub(super) enum Primitive {
     Write,
     WriteError,
     Halt,
+    Code,
+    Data,
 }
 
 impl Primitive {
@@ -44,4 +46,6 @@ impl Primitive {
     pub const WRITE: u8 = Self::Write as _;
     pub const WRITE_ERROR: u8 = Self::WriteError as _;
     pub const HALT: u8 = Self::Halt as _;
+    pub const CODE: u8 = Self::Code as _;
+    pub const DATA: u8 = Self::Data as _;
 }


### PR DESCRIPTION
This didn't improve the performance?

Before:

```sh
Benchmark 1: stak-interpret bench/fibonacci/main.out
  Time (mean ± σ):      8.995 s ±  0.102 s    [User: 8.914 s, System: 0.007 s]
  Range (min … max):    8.794 s …  9.133 s    10 runs
```

After:

```sh
Benchmark 1: stak-interpret bench/fibonacci/main.out
  Time (mean ± σ):      9.232 s ±  0.203 s    [User: 9.122 s, System: 0.008 s]
  Range (min … max):    8.964 s …  9.697 s    10 runs
```