### PR TITLE
Revert "Make doc test `no_std` (#687)"

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -3,8 +3,6 @@
 //! # Examples
 //!
 //! ```rust
-//! #[no_std]
-//!
 //! use stak_device::FixedBufferDevice;
 //! use stak_macro::compile_r7rs;
 //! use stak_primitive::SmallPrimitiveSet;


### PR DESCRIPTION
This reverts commit c4300a8e5126ae5934ed66f7d1b32df093f75eb3.
