### PR TITLE
Remove empty symbols

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -39,6 +39,8 @@
 
 ; Constants
 
+; We need to generate those symbols from strings to match them with the ones
+; from a `read` procedure.
 (define rib-symbol (string->symbol "$$rib"))
 
 (define default-constants

--- a/compile.scm
+++ b/compile.scm
@@ -42,12 +42,16 @@
 (define rib-symbol (string->symbol "$$rib"))
 
 (define default-constants
-  (list
-    (cons #f (string->symbol "$$false"))
-    (cons #t (string->symbol "$$true"))
-    (cons '() (string->symbol "$$null"))
-    ; It is fine to have a key duplicate with `false`'s because it is never hit.
-    (cons #f rib-symbol)))
+  (map
+    (lambda (pair)
+      (cons
+        (car pair)
+        (string->symbol (cdr pair))))
+    '((#f . "$$false")
+      (#t . "$$true")
+      (() . "$$null")
+      ; It is fine to have a key duplicate with `false`'s because it is never hit.
+      (#f . "$$rib"))))
 
 (define default-symbols (map cdr default-constants))
 

--- a/compile.scm
+++ b/compile.scm
@@ -46,11 +46,12 @@
 ; Constants
 
 (define default-constants
-  '((#f . $$false)
-    (#t . $$true)
-    (() . $$null)
+  (list
+    (cons #f (string->symbol "$$false"))
+    (cons #t (string->symbol "$$true"))
+    (cons '() (string->symbol "$$null"))
     ; It is fine to have a key duplicate with `false`'s because it is never hit.
-    (#f . $$rib)))
+    (cons #f (string->symbol "$$rib"))))
 
 (define default-symbols (map cdr default-constants))
 

--- a/compile.scm
+++ b/compile.scm
@@ -12,13 +12,7 @@
   (stak
     (define cons-rib cons)
     (define target-pair? pair?)
-    (define target-procedure? procedure?)
-
-    ; Internal symbols must be discoverable with their string representations.
-    (set-car! '$$false "$$false")
-    (set-car! '$$true "$$true")
-    (set-car! '$$null "$$null")
-    (set-car! '$$rib "$$rib"))
+    (define target-procedure? procedure?))
 
   (else
     (define-record-type *rib*
@@ -45,13 +39,15 @@
 
 ; Constants
 
+(define rib-symbol (string->symbol "$$rib"))
+
 (define default-constants
   (list
     (cons #f (string->symbol "$$false"))
     (cons #t (string->symbol "$$true"))
     (cons '() (string->symbol "$$null"))
     ; It is fine to have a key duplicate with `false`'s because it is never hit.
-    (cons #f (string->symbol "$$rib"))))
+    (cons #f rib-symbol)))
 
 (define default-symbols (map cdr default-constants))
 
@@ -857,11 +853,10 @@
       (($$cons $$-)
         2)
 
-      (($$rib)
-        4)
-
       (else
-        (error "unknown primitive" name)))
+        (if (eq? name rib-symbol)
+          4
+          (error "unknown primitive" name))))
     name
     continuation))
 
@@ -1064,7 +1059,7 @@
           (code-rib
             constant-instruction
             0
-            (compile-primitive-call '$$rib (continue)))))))
+            (compile-primitive-call rib-symbol (continue)))))))
 
   (let ((symbol (constant-context-constant context constant)))
     (if symbol
@@ -1371,7 +1366,7 @@
           constant-instruction
           0
           (compile-primitive-call
-            '$$rib
+            rib-symbol
             (code-rib set-instruction (car primitive) continuation)))))))
 
 (define (build-primitives primitives continuation)

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -573,7 +573,8 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
 
         trace!("decode", "start");
 
-        self.decode_symbols(&mut input)?;
+        self.register = self.decode_symbols(&mut input)?;
+        self.stack = self.null();
         self.decode_instructions(&mut input)?;
 
         trace!("decode", "end");
@@ -589,7 +590,7 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
         Ok(())
     }
 
-    fn decode_symbols(&mut self, input: &mut impl Iterator<Item = u8>) -> Result<(), T::Error> {
+    fn decode_symbols(&mut self, input: &mut impl Iterator<Item = u8>) -> Result<Cons, T::Error> {
         // Initialize a shared empty string.
         self.register = self.create_string(self.null(), 0)?;
 
@@ -639,11 +640,7 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
             self.stack.into(),
         );
 
-        // Allow access to a symbol table during decoding.
-        self.register = self.stack;
-        self.stack = self.null();
-
-        Ok(())
+        Ok(self.stack)
     }
 
     fn initialize_empty_symbol(&mut self, value: Value) -> Result<(), T::Error> {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -653,7 +653,7 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
 
         // Set a rib primitive's environment to a symbol table for access from a base
         // library.
-        self.set_car_value(self.cdr(self.stack), self.cdr(self.register).into());
+        self.set_car_value(self.cdr(self.stack), self.cdr(self.register));
 
         Ok(())
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -646,11 +646,11 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
 
         let mut current = self.register;
 
-        while self.cdr_value(self.cdr(current)) != self.null().into() {
-            if self.is_empty_symbol(self.car_value(self.cdr_value(self.cdr(current)))) {
-                current = self.cdr(current).assume_cons()
-            } else {
+        while self.cdr(current) != self.null().into() {
+            if self.is_empty_symbol(self.car_value(self.cdr(current))) {
                 self.set_cdr(current, self.cdr_value(self.cdr(current)));
+            } else {
+                current = self.cdr(current).assume_cons()
             }
         }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -573,6 +573,7 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
 
         trace!("decode", "start");
 
+        // Allow access to a symbol table during instruction decoding.
         self.register = self.decode_symbols(&mut input)?;
         self.stack = self.null();
         self.decode_instructions(&mut input)?;


### PR DESCRIPTION
```
> hyperfine '~/worktree/ef6115a43fa7bb85/target/release/stak ~/foo.scm' 'target/release/stak ~/foo.scm'
Benchmark 1: ~/worktree/ef6115a43fa7bb85/target/release/stak ~/foo.scm
  Time (mean ± σ):      2.130 s ±  0.006 s    [User: 2.115 s, System: 0.004 s]
  Range (min … max):    2.125 s …  2.145 s    10 runs

Benchmark 2: target/release/stak ~/foo.scm
  Time (mean ± σ):      1.985 s ±  0.011 s    [User: 1.969 s, System: 0.004 s]
  Range (min … max):    1.978 s …  2.016 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  target/release/stak ~/foo.scm ran
    1.07 ± 0.01 times faster than ~/worktree/ef6115a43fa7bb85/target/release/stak ~/foo.scm
```