### PR TITLE
Replace `eqv?` with `eq?`

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -164,7 +164,7 @@
       (loop
         (cdr xs)
         (let ((x (car xs)))
-          (if (memv x ys)
+          (if (memq x ys)
             ys
             (cons x ys)))))))
 
@@ -350,7 +350,7 @@
 (define (rename-library-symbol id name)
   (if (or
        (eqv? (string-ref (symbol->string name) 0) #\$)
-       (memv name keywords)
+       (memq name keywords)
        (not id))
     name
     (string->symbol
@@ -465,7 +465,7 @@
 
 (define (expansion-context-set! context name denotation)
   (let* ((environment (expansion-context-environment context))
-         (pair (assv name environment)))
+         (pair (assq name environment)))
     (when pair (set-cdr! pair denotation))
     pair))
 
@@ -510,7 +510,7 @@
       ((and
           (list? expression)
           (= (length expression) 3)
-          (assv predicate primitive-functions))
+          (assq predicate primitive-functions))
         =>
         (lambda (pair)
           (cons (cdr pair) (cdr expression))))
@@ -520,7 +520,7 @@
 
 (define (resolve-denotation context expression)
   (cond
-    ((assv expression (expansion-context-environment context)) =>
+    ((assq expression (expansion-context-environment context)) =>
       cdr)
 
     (else
@@ -537,7 +537,7 @@
 (define (find-pattern-variables bound-variables pattern)
   (define (find pattern)
     (cond
-      ((memv pattern (append '(_ ...) bound-variables))
+      ((memq pattern (append '(_ ...) bound-variables))
         '())
 
       ((symbol? pattern)
@@ -571,7 +571,7 @@
                       (cons name
                         (cons
                           (cdr pair)
-                          (cdr (assv name all))))))
+                          (cdr (assq name all))))))
                   ones)))
             (map
               (lambda (name) (cons name '()))
@@ -595,7 +595,7 @@
     ((eq? pattern '_)
       '())
 
-    ((memv pattern literals)
+    ((memq pattern literals)
       (if (eq?
            (resolve-denotation use-context expression)
            (resolve-denotation definition-context pattern))
@@ -640,7 +640,7 @@
   (map
     (lambda (matches) (fill-template definition-context use-context matches template))
     (let* ((variables (find-pattern-variables '() template))
-           (matches (filter (lambda (pair) (memv (car pair) variables)) matches))
+           (matches (filter (lambda (pair) (memq (car pair) variables)) matches))
            (singleton-matches (filter (lambda (pair) (not (ellipsis-match? (cdr pair)))) matches))
            (ellipsis-matches (filter (lambda (pair) (ellipsis-match? (cdr pair))) matches)))
       (when (null? ellipsis-matches)
@@ -660,7 +660,7 @@
   (cond
     ((symbol? template)
       (cond
-        ((assv template matches) =>
+        ((assq template matches) =>
           cdr)
 
         ; Skip a literal.
@@ -1175,9 +1175,9 @@
 
             ((and
                 (symbol? operand)
-                (not (memv operand default-symbols))
-                (not (memv operand constant-symbols))
-                (not (memv operand symbols)))
+                (not (memq operand default-symbols))
+                (not (memq operand constant-symbols))
+                (not (memq operand symbols)))
               (cons operand symbols))
 
             (else
@@ -1317,7 +1317,7 @@
         context
         codes
         (cond
-          ((memv instruction (list set-instruction get-instruction))
+          ((memq instruction (list set-instruction get-instruction))
             (encode-simple instruction))
 
           ((eq? instruction call-instruction)

--- a/compile.scm
+++ b/compile.scm
@@ -27,7 +27,7 @@
       (rib pair-type car cdr 0))
 
     (define (instance? value type)
-      (and (rib? value) (eqv? (rib-type value) type)))
+      (and (rib? value) (eq? (rib-type value) type)))
 
     (define (target-pair? value)
       (instance? value pair-type))
@@ -412,7 +412,7 @@
                  (flat-map
                    cdr
                    (filter
-                     (lambda (body) (eqv? (car body) predicate))
+                     (lambda (body) (eq? (car body) predicate))
                      (cddr expression)))))
              (id (library-context-id context)))
         (library-context-add!
@@ -491,7 +491,7 @@
 (define (optimize expression)
   (let ((predicate (predicate expression)))
     (cond
-      ((eqv? predicate '$$begin)
+      ((eq? predicate '$$begin)
         ; Omit top-level constants.
         (cons '$$begin
           (let loop ((expressions (cdr expression)))
@@ -530,7 +530,7 @@
   (let* ((denotation (resolve-denotation context name))
          (count
            (list-count
-             (lambda (pair) (eqv? (cdr pair) denotation))
+             (lambda (pair) (eq? (cdr pair) denotation))
              (expansion-context-environment context))))
     (string->uninterned-symbol (string-append (symbol->string name) "$" (id->string count)))))
 
@@ -592,11 +592,11 @@
     (match-pattern definition-context use-context literals pattern expression))
 
   (cond
-    ((eqv? pattern '_)
+    ((eq? pattern '_)
       '())
 
     ((memv pattern literals)
-      (if (eqv?
+      (if (eq?
            (resolve-denotation use-context expression)
            (resolve-denotation definition-context pattern))
         '()
@@ -609,7 +609,7 @@
       (cond
         ((and
             (pair? (cdr pattern))
-            (eqv? (cadr pattern) '...))
+            (eq? (cadr pattern) '...))
           (let ((length (- (relaxed-length expression) (- (relaxed-length pattern) 2))))
             (and
               (>= length 0)
@@ -670,7 +670,7 @@
     ((pair? template)
       (if (and
            (pair? (cdr template))
-           (eqv? (cadr template) '...))
+           (eq? (cadr template) '...))
         (append
           (fill-ellipsis-template definition-context use-context matches (car template))
           (fill (cddr template)))
@@ -869,8 +869,8 @@
 (define (drop? codes)
   (and
     (target-pair? codes)
-    (eqv? (rib-tag codes) set-instruction)
-    (eqv? (rib-car codes) 0)))
+    (eq? (rib-tag codes) set-instruction)
+    (eq? (rib-car codes) 0)))
 
 (define (compile-unspecified continuation)
   (if (drop? continuation)
@@ -1134,7 +1134,7 @@
              (codes (rib-cdr codes))
              (continue (lambda () (loop codes continue))))
         (cond
-          ((eqv? instruction constant-instruction)
+          ((eq? instruction constant-instruction)
             (build-constant
               context
               operand
@@ -1142,7 +1142,7 @@
                 (lambda () (loop (procedure-code operand) continue))
                 continue)))
 
-          ((eqv? instruction if-instruction)
+          ((eq? instruction if-instruction)
             (loop operand continue))
 
           (else
@@ -1159,18 +1159,18 @@
       (let* ((instruction (rib-tag codes))
              (operand (rib-car codes))
              (operand
-               (if (eqv? instruction call-instruction)
+               (if (eq? instruction call-instruction)
                  (rib-cdr operand)
                  operand)))
         (loop
           (rib-cdr codes)
           (cond
             ((and
-                (eqv? instruction constant-instruction)
+                (eq? instruction constant-instruction)
                 (target-procedure? operand))
               (loop (procedure-code operand) symbols))
 
-            ((eqv? instruction if-instruction)
+            ((eq? instruction if-instruction)
               (loop operand symbols))
 
             ((and
@@ -1186,7 +1186,7 @@
 (define (nop-codes? codes)
   (and
     (target-pair? codes)
-    (eqv? (rib-tag codes) nop-instruction)))
+    (eq? (rib-tag codes) nop-instruction)))
 
 (define (terminal-codes? codes)
   (or (null? codes) (nop-codes? codes)))
@@ -1320,7 +1320,7 @@
           ((memv instruction (list set-instruction get-instruction))
             (encode-simple instruction))
 
-          ((eqv? instruction call-instruction)
+          ((eq? instruction call-instruction)
             (encode-instruction
               instruction
               (rib-car operand)
@@ -1328,11 +1328,11 @@
               (encode-integer (encode-operand context (rib-cdr operand)) target)))
 
           ((and
-              (eqv? instruction constant-instruction)
+              (eq? instruction constant-instruction)
               (target-procedure? operand))
             (encode-procedure context operand return target))
 
-          ((eqv? instruction constant-instruction)
+          ((eq? instruction constant-instruction)
             (let ((symbol (encode-context-constant context operand)))
               (if symbol
                 (encode-instruction
@@ -1342,7 +1342,7 @@
                   target)
                 (encode-simple constant-instruction))))
 
-          ((eqv? instruction if-instruction)
+          ((eq? instruction if-instruction)
             (let ((continuation (find-continuation operand))
                   (target
                     (encode-codes

--- a/prelude.scm
+++ b/prelude.scm
@@ -1354,7 +1354,7 @@
 
     (define (error-type? type)
       (lambda (error)
-        (eqv? (error-object-type error) type)))
+        (eq? (error-object-type error) type)))
 
     (define error (error-type #f))
     (define read-error (error-type 'read))

--- a/prelude.scm
+++ b/prelude.scm
@@ -1646,7 +1646,7 @@
                         ((null? x)
                           (read-char))
 
-                        ((eqv? (length x) 1)
+                        ((eq? (length x) 1)
                           (car x))
 
                         (else
@@ -1828,7 +1828,7 @@
           ((not x)
             (write-string "#f"))
 
-          ((eqv? x #t)
+          ((eq? x #t)
             (write-string "#t"))
 
           ((bytevector? x)
@@ -1925,7 +1925,7 @@
     (define exit-success (data-rib procedure-type #f (cons 0 '())))
 
     (define (emergency-exit . rest)
-      (if (or (null? rest) (eqv? (car rest) #t))
+      (if (or (null? rest) (eq? (car rest) #t))
         (exit-success)
         ($$halt)))
 

--- a/prelude.scm
+++ b/prelude.scm
@@ -724,7 +724,7 @@
 
     (define (eqv? x y)
       (if (and (char? x) (char? y))
-        (eqv? (char->integer x) (char->integer y))
+        (eq? (char->integer x) (char->integer y))
         (eq? x y)))
 
     (define (equal? x y)
@@ -765,7 +765,7 @@
     (define (exact? x) #t)
     (define (inexact? x) #f)
 
-    (define (zero? x) (eqv? x 0))
+    (define (zero? x) (eq? x 0))
     (define (positive? x) (> x 0))
     (define (negative? x) (< x 0))
 
@@ -787,9 +787,9 @@
     (define (modulo x y)
       (let ((q (quotient x y)))
         (let ((r (- x (* y q))))
-          (if (eqv? r 0)
+          (if (eq? r 0)
             0
-            (if (eqv? (< x 0) (< y 0))
+            (if (eq? (< x 0) (< y 0))
               r
               (+ r y))))))
 
@@ -804,7 +804,7 @@
               (let ((y (car xs)))
                 (and (f x y) (loop y (cdr xs)))))))))
 
-    (define = (comparison-operator eqv?))
+    (define = (comparison-operator eq?))
     (define < (comparison-operator $$<))
     (define > (comparison-operator (lambda (x y) ($$< y x))))
     (define <= (comparison-operator (lambda (x y) (not ($$< y x)))))


### PR DESCRIPTION
```
> hyperfine -w 5 '~/src/github.com/raviqqe/stak/target/release/stak ~/foo.scm' 'target/release/stak ~/foo.scm'
Benchmark 1: ~/src/github.com/raviqqe/stak/target/release/stak ~/foo.scm
  Time (mean ± σ):      1.989 s ±  0.021 s    [User: 1.975 s, System: 0.003 s]
  Range (min … max):    1.972 s …  2.027 s    10 runs

Benchmark 2: target/release/stak ~/foo.scm
  Time (mean ± σ):      1.809 s ±  0.006 s    [User: 1.798 s, System: 0.003 s]
  Range (min … max):    1.803 s …  1.821 s    10 runs

Summary
  target/release/stak ~/foo.scm ran
    1.10 ± 0.01 times faster than ~/src/github.com/raviqqe/stak/target/release/stak ~/foo.scm
```