### PR TITLE
Optimize `string-append`

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -524,7 +524,7 @@
            (list-count
              (lambda (pair) (eq? (cdr pair) denotation))
              (expansion-context-environment context))))
-    (string->uninterned-symbol (string-append (symbol->string name) "$" (id->string count)))))
+    (string->uninterned-symbol (string-append (id->string count) "$" (symbol->string name)))))
 
 (define (find-pattern-variables bound-variables pattern)
   (define (find pattern)

--- a/compile.scm
+++ b/compile.scm
@@ -524,6 +524,7 @@
            (list-count
              (lambda (pair) (eq? (cdr pair) denotation))
              (expansion-context-environment context))))
+    ; Share tails when appending strings.
     (string->uninterned-symbol (string-append (id->string count) "$" (symbol->string name)))))
 
 (define (find-pattern-variables bound-variables pattern)

--- a/prelude.scm
+++ b/prelude.scm
@@ -1042,6 +1042,8 @@
 
     (define string->code-points rib-car)
 
+    (define string-length rib-cdr)
+
     (define (list->string x)
       (data-rib string-type (map char->integer x) (length x)))
 
@@ -1050,8 +1052,6 @@
 
     (define (string-append . xs)
       (list->string (apply append (map string->list xs))))
-
-    (define string-length rib-cdr)
 
     (define (string-ref x index)
       (integer->char (list-ref (string->code-points x) index)))

--- a/prelude.scm
+++ b/prelude.scm
@@ -1050,11 +1050,11 @@
     (define (string->list x)
       (map integer->char (string->code-points x)))
 
-    (define (string-append . xs)
-      (list->string (apply append (map string->list xs))))
-
     (define (string-ref x index)
       (integer->char (list-ref (string->code-points x) index)))
+
+    (define (string-append . xs)
+      (code-points->string (apply append (map string->code-points xs))))
 
     (define (number->string x . rest)
       (let ((radix (if (null? rest) 10 (car rest))))

--- a/prelude.scm
+++ b/prelude.scm
@@ -1039,15 +1039,18 @@
 
     (define string? (instance? string-type))
 
+    (define (string-rib codes length)
+      (data-rib string-type codes length))
+
     (define (code-points->string x)
-      (data-rib string-type x (length x)))
+      (string-rib x (length x)))
 
     (define string->code-points rib-car)
 
     (define string-length rib-cdr)
 
     (define (list->string x)
-      (data-rib string-type (map char->integer x) (length x)))
+      (string-rib (map char->integer x) (length x)))
 
     (define (string->list x)
       (map integer->char (string->code-points x)))

--- a/prelude.scm
+++ b/prelude.scm
@@ -1122,7 +1122,7 @@
           (convert xs))))
 
     (define (string-copy x . rest)
-      (list->string (apply list-copy (cons (string->list x) rest))))
+      (code-points->string (apply list-copy (cons (string->code-points x) rest))))
 
     (define substring string-copy)
 

--- a/prelude.scm
+++ b/prelude.scm
@@ -1037,11 +1037,16 @@
 
     (define string? (instance? string-type))
 
+    (define (code-points->string x)
+      (data-rib string-type x (length x)))
+
+    (define string->code-points rib-car)
+
     (define (list->string x)
       (data-rib string-type (map char->integer x) (length x)))
 
     (define (string->list x)
-      (map integer->char (rib-car x)))
+      (map integer->char (string->code-points x)))
 
     (define (string-append . xs)
       (list->string (apply append (map string->list xs))))
@@ -1049,7 +1054,7 @@
     (define string-length rib-cdr)
 
     (define (string-ref x index)
-      (integer->char (list-ref (rib-car x) index)))
+      (integer->char (list-ref (string->code-points x) index)))
 
     (define (number->string x . rest)
       (let ((radix (if (null? rest) 10 (car rest))))


### PR DESCRIPTION
# Hello world benchmark

```
> hyperfine -w 10 '~/worktree/7a1181edfad9f3e5/target/release/stak ~/foo.scm' 'target/release/stak ~/foo.scm'
Benchmark 1: ~/worktree/7a1181edfad9f3e5/target/release/stak ~/foo.scm
  Time (mean ± σ):      1.805 s ±  0.003 s    [User: 1.792 s, System: 0.004 s]
  Range (min … max):    1.802 s …  1.810 s    10 runs

Benchmark 2: target/release/stak ~/foo.scm
  Time (mean ± σ):      1.787 s ±  0.004 s    [User: 1.775 s, System: 0.004 s]
  Range (min … max):    1.783 s …  1.797 s    10 runs

Summary
  target/release/stak ~/foo.scm ran
    1.01 ± 0.00 times faster than ~/worktree/7a1181edfad9f3e5/target/release/stak ~/foo.scm
```

This is not that fast...

# GC benchmark

~~A number of GC is 4 times smaller than before in the self-hosted compiler.~~ I didn't rebase to the `main` branch.

## Before

```sh
> cargo run --release --bin stak compile.scm < prelude.scm < compile.scm > out.bc 2> gc.log && wc gc.log
   12112   12134   36824 gc.log
```

## After

```sh
> cargo run --release --bin stak compile.scm < prelude.scm < compile.scm > out.bc 2> gc.log && wc gc.log
   11707   11729   35609 gc.log
```

Even after a0068f4c654be99abb9ae826dad924c57813cf2c,

```
> cargo run --release --bin stak compile.scm < prelude.scm < compile.scm > out.bc 2> gc.log && wc gc.log
   11594   11610   35112 gc.log
```