### PR TITLE
Encode full symbol table

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -39,21 +39,12 @@
 
 ; Constants
 
-; We need to generate those symbols from strings to match them with the ones
-; from a `read` procedure.
-(define rib-symbol (string->symbol "$$rib"))
-
 (define default-constants
-  (map
-    (lambda (pair)
-      (cons
-        (car pair)
-        (string->symbol (cdr pair))))
-    '((#f . "$$false")
-      (#t . "$$true")
-      (() . "$$null")
-      ; It is fine to have a key duplicate with `false`'s because it is never hit.
-      (#f . "$$rib"))))
+  '((#f . $$false)
+    (#t . $$true)
+    (() . $$null)
+    ; It is fine to have a key duplicate with `false`'s because it is never hit.
+    (#f . $$rib)))
 
 (define default-symbols (map cdr default-constants))
 
@@ -860,7 +851,7 @@
         2)
 
       (else
-        (if (eq? name rib-symbol)
+        (if (eq? name '$$rib)
           4
           (error "unknown primitive" name))))
     name
@@ -1065,7 +1056,7 @@
           (code-rib
             constant-instruction
             0
-            (compile-primitive-call rib-symbol (continue)))))))
+            (compile-primitive-call '$$rib (continue)))))))
 
   (let ((symbol (constant-context-constant context constant)))
     (if symbol
@@ -1372,7 +1363,7 @@
           constant-instruction
           0
           (compile-primitive-call
-            rib-symbol
+            '$$rib
             (code-rib set-instruction (car primitive) continuation)))))))
 
 (define (build-primitives primitives continuation)

--- a/compile.scm
+++ b/compile.scm
@@ -1391,13 +1391,13 @@
              primitives
              (build-constants constant-context codes)))
          (constant-symbols (map cdr (constant-context-constants constant-context)))
-         (symbols (find-symbols constant-symbols codes)))
+         (symbols (append default-symbols (find-symbols constant-symbols codes))))
     (encode-symbols
       symbols
       constant-symbols
       (encode-codes
         (make-encode-context
-          (append default-symbols symbols constant-symbols)
+          (append symbols constant-symbols)
           constant-context)
         codes
         '()))))

--- a/compile.scm
+++ b/compile.scm
@@ -39,12 +39,21 @@
 
 ; Constants
 
+; We need to generate those symbols from strings to match them with the ones
+; from a `read` procedure.
+(define rib-symbol (string->symbol "$$rib"))
+
 (define default-constants
-  '((#f . $$false)
-    (#t . $$true)
-    (() . $$null)
-    ; It is fine to have a key duplicate with `false`'s because it is never hit.
-    (#f . $$rib)))
+  (map
+    (lambda (pair)
+      (cons
+        (car pair)
+        (string->symbol (cdr pair))))
+    '((#f . "$$false")
+      (#t . "$$true")
+      (() . "$$null")
+      ; It is fine to have a key duplicate with `false`'s because it is never hit.
+      (#f . "$$rib"))))
 
 (define default-symbols (map cdr default-constants))
 
@@ -851,7 +860,7 @@
         2)
 
       (else
-        (if (eq? name '$$rib)
+        (if (eq? name rib-symbol)
           4
           (error "unknown primitive" name))))
     name
@@ -1056,7 +1065,7 @@
           (code-rib
             constant-instruction
             0
-            (compile-primitive-call '$$rib (continue)))))))
+            (compile-primitive-call rib-symbol (continue)))))))
 
   (let ((symbol (constant-context-constant context constant)))
     (if symbol
@@ -1363,7 +1372,7 @@
           constant-instruction
           0
           (compile-primitive-call
-            '$$rib
+            rib-symbol
             (code-rib set-instruction (car primitive) continuation)))))))
 
 (define (build-primitives primitives continuation)

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -871,7 +871,7 @@ impl<'a, T: PrimitiveSet> Display for Vm<'a, T> {
 mod tests {
     use super::*;
     use crate::symbol_index;
-    use alloc::vec;
+    use alloc::{string::String, vec, vec::Vec};
     use code::{encode, Instruction, Operand, Program};
 
     const HEAP_SIZE: usize = 1 << 9;
@@ -904,6 +904,10 @@ mod tests {
 
             let _ = $vm;
         };
+    }
+
+    fn default_symbols() -> Vec<String> {
+        vec!["".into(), "".into(), "".into(), "".into()]
     }
 
     #[test]
@@ -1065,13 +1069,13 @@ mod tests {
 
         #[test]
         fn run_nothing() {
-            run_program(&Program::new(vec![], vec![]));
+            run_program(&Program::new(default_symbols().clone(), vec![]));
         }
 
         #[test]
         fn constant() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![Instruction::Constant(Operand::Integer(42))],
             ));
         }
@@ -1079,7 +1083,7 @@ mod tests {
         #[test]
         fn create_closure() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![Instruction::Close(
                     0,
                     vec![Instruction::Constant(Operand::Integer(0))],
@@ -1090,7 +1094,7 @@ mod tests {
         #[test]
         fn get_closure() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Close(0, vec![Instruction::Constant(Operand::Integer(0))]),
                     Instruction::Get(Operand::Integer(0)),
@@ -1101,7 +1105,7 @@ mod tests {
         #[test]
         fn set_global() {
             run_program(&Program::new(
-                vec!["x".into()],
+                default_symbols().into_iter().chain(["x".into()]).collect(),
                 vec![
                     Instruction::Constant(Operand::Integer(42)),
                     Instruction::Set(Operand::Symbol(symbol_index::OTHER)),
@@ -1112,7 +1116,7 @@ mod tests {
         #[test]
         fn set_empty_global() {
             run_program(&Program::new(
-                vec!["".into()],
+                default_symbols().into_iter().chain(["".into()]).collect(),
                 vec![
                     Instruction::Constant(Operand::Integer(42)),
                     Instruction::Set(Operand::Symbol(symbol_index::OTHER)),
@@ -1123,7 +1127,10 @@ mod tests {
         #[test]
         fn set_second_global() {
             run_program(&Program::new(
-                vec!["x".into(), "y".into()],
+                default_symbols()
+                    .into_iter()
+                    .chain(["x".into(), "y".into()])
+                    .collect(),
                 vec![
                     Instruction::Constant(Operand::Integer(42)),
                     Instruction::Set(Operand::Symbol(symbol_index::OTHER + 1)),
@@ -1134,7 +1141,10 @@ mod tests {
         #[test]
         fn set_second_empty_global() {
             run_program(&Program::new(
-                vec!["".into(), "".into()],
+                default_symbols()
+                    .into_iter()
+                    .chain(["".into(), "".into()])
+                    .collect(),
                 vec![
                     Instruction::Constant(Operand::Integer(42)),
                     Instruction::Set(Operand::Symbol(symbol_index::OTHER + 1)),
@@ -1145,7 +1155,7 @@ mod tests {
         #[test]
         fn set_local() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Set(Operand::Integer(0)),
@@ -1156,7 +1166,7 @@ mod tests {
         #[test]
         fn set_second_local() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Constant(Operand::Integer(0)),
@@ -1168,7 +1178,11 @@ mod tests {
         #[test]
         fn get_global() {
             run_program(&Program::new(
-                vec!["x".into()],
+                default_symbols()
+                    .iter()
+                    .cloned()
+                    .chain(["x".into()])
+                    .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER))],
             ));
         }
@@ -1176,7 +1190,11 @@ mod tests {
         #[test]
         fn get_empty_global() {
             run_program(&Program::new(
-                vec!["".into()],
+                default_symbols()
+                    .iter()
+                    .cloned()
+                    .chain(["".into()])
+                    .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER))],
             ));
         }
@@ -1184,7 +1202,11 @@ mod tests {
         #[test]
         fn get_second_global() {
             run_program(&Program::new(
-                vec!["x".into(), "y".into()],
+                default_symbols()
+                    .iter()
+                    .cloned()
+                    .chain(["x".into(), "y".into()])
+                    .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER + 1))],
             ));
         }
@@ -1192,7 +1214,11 @@ mod tests {
         #[test]
         fn get_second_empty_global() {
             run_program(&Program::new(
-                vec!["".into(), "".into()],
+                default_symbols()
+                    .iter()
+                    .cloned()
+                    .chain(["".into(), "".into()])
+                    .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER + 1))],
             ));
         }
@@ -1200,7 +1226,7 @@ mod tests {
         #[test]
         fn get_built_in_globals() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::FALSE)),
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
@@ -1213,7 +1239,7 @@ mod tests {
         #[test]
         fn get_local() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Get(Operand::Integer(0)),
@@ -1224,7 +1250,7 @@ mod tests {
         #[test]
         fn get_second_local() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Constant(Operand::Integer(0)),
@@ -1236,7 +1262,7 @@ mod tests {
         #[test]
         fn if_with_false() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::FALSE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1247,7 +1273,7 @@ mod tests {
         #[test]
         fn if_with_true() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1258,7 +1284,7 @@ mod tests {
         #[test]
         fn if_with_continuation() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1270,7 +1296,7 @@ mod tests {
         #[test]
         fn if_with_skip_instruction() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![
@@ -1286,7 +1312,7 @@ mod tests {
         #[test]
         fn multiple_if() {
             run_program(&Program::new(
-                vec![],
+                default_symbols().clone(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1069,13 +1069,13 @@ mod tests {
 
         #[test]
         fn run_nothing() {
-            run_program(&Program::new(default_symbols().clone(), vec![]));
+            run_program(&Program::new(default_symbols(), vec![]));
         }
 
         #[test]
         fn constant() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![Instruction::Constant(Operand::Integer(42))],
             ));
         }
@@ -1083,7 +1083,7 @@ mod tests {
         #[test]
         fn create_closure() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![Instruction::Close(
                     0,
                     vec![Instruction::Constant(Operand::Integer(0))],
@@ -1094,7 +1094,7 @@ mod tests {
         #[test]
         fn get_closure() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Close(0, vec![Instruction::Constant(Operand::Integer(0))]),
                     Instruction::Get(Operand::Integer(0)),
@@ -1155,7 +1155,7 @@ mod tests {
         #[test]
         fn set_local() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Set(Operand::Integer(0)),
@@ -1166,7 +1166,7 @@ mod tests {
         #[test]
         fn set_second_local() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Constant(Operand::Integer(0)),
@@ -1178,11 +1178,7 @@ mod tests {
         #[test]
         fn get_global() {
             run_program(&Program::new(
-                default_symbols()
-                    .iter()
-                    .cloned()
-                    .chain(["x".into()])
-                    .collect(),
+                default_symbols().into_iter().chain(["x".into()]).collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER))],
             ));
         }
@@ -1190,11 +1186,7 @@ mod tests {
         #[test]
         fn get_empty_global() {
             run_program(&Program::new(
-                default_symbols()
-                    .iter()
-                    .cloned()
-                    .chain(["".into()])
-                    .collect(),
+                default_symbols().into_iter().chain(["".into()]).collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER))],
             ));
         }
@@ -1203,8 +1195,7 @@ mod tests {
         fn get_second_global() {
             run_program(&Program::new(
                 default_symbols()
-                    .iter()
-                    .cloned()
+                    .into_iter()
                     .chain(["x".into(), "y".into()])
                     .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER + 1))],
@@ -1215,8 +1206,7 @@ mod tests {
         fn get_second_empty_global() {
             run_program(&Program::new(
                 default_symbols()
-                    .iter()
-                    .cloned()
+                    .into_iter()
                     .chain(["".into(), "".into()])
                     .collect(),
                 vec![Instruction::Get(Operand::Symbol(symbol_index::OTHER + 1))],
@@ -1226,7 +1216,7 @@ mod tests {
         #[test]
         fn get_built_in_globals() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::FALSE)),
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
@@ -1239,7 +1229,7 @@ mod tests {
         #[test]
         fn get_local() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Get(Operand::Integer(0)),
@@ -1250,7 +1240,7 @@ mod tests {
         #[test]
         fn get_second_local() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Constant(Operand::Integer(0)),
                     Instruction::Constant(Operand::Integer(0)),
@@ -1262,7 +1252,7 @@ mod tests {
         #[test]
         fn if_with_false() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::FALSE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1273,7 +1263,7 @@ mod tests {
         #[test]
         fn if_with_true() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1284,7 +1274,7 @@ mod tests {
         #[test]
         fn if_with_continuation() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),
@@ -1296,7 +1286,7 @@ mod tests {
         #[test]
         fn if_with_skip_instruction() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![
@@ -1312,7 +1302,7 @@ mod tests {
         #[test]
         fn multiple_if() {
             run_program(&Program::new(
-                default_symbols().clone(),
+                default_symbols(),
                 vec![
                     Instruction::Get(Operand::Symbol(symbol_index::TRUE)),
                     Instruction::If(vec![Instruction::Constant(Operand::Integer(0))]),

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -907,7 +907,7 @@ mod tests {
     }
 
     fn default_symbols() -> Vec<String> {
-        vec!["".into(), "".into(), "".into(), "".into()]
+        vec![Default::default(); symbol_index::OTHER as usize]
     }
 
     #[test]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -627,10 +627,12 @@ impl<'a, T: PrimitiveSet> Vm<'a, T> {
             Number::default().into(),
         )?;
 
-        self.initialize_empty_symbol(rib.into())?;
-        self.initialize_empty_symbol(self.null().into())?;
-        self.initialize_empty_symbol(self.boolean(true).into())?;
-        self.initialize_empty_symbol(self.boolean(false).into())?;
+        let mut cons = self.stack;
+
+        for value in [self.boolean(false), self.boolean(true), self.null(), rib] {
+            self.set_cdr_value(self.car(cons), value.into());
+            cons = self.cdr(cons).assume_cons();
+        }
 
         Ok(self.stack)
     }


### PR DESCRIPTION
This allows us to avoid the `$$rib` symbol re-generation hack.