### PR TITLE
Exception-based matching

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -579,17 +579,16 @@
   (let ((matches
           (fold-right
             (lambda (all ones)
-              (and
-                all
-                ones
-                (map
-                  (lambda (pair)
-                    (let ((name (car pair)))
-                      (cons name
-                        (cons
-                          (cdr pair)
-                          (cdr (assq name all))))))
-                  ones)))
+              (unless ones
+                (raise #f))
+              (map
+                (lambda (pair)
+                  (let ((name (car pair)))
+                    (cons name
+                      (cons
+                        (cdr pair)
+                        (cdr (assq name all))))))
+                ones))
             (map
               (lambda (name) (cons name '()))
               (find-pattern-variables context (rule-context-literals context) pattern))

--- a/prelude.scm
+++ b/prelude.scm
@@ -2263,9 +2263,9 @@
     (set! write-value write)))
 
 (define-library (scheme process-context)
-  (import (scheme base) (stak base))
-
   (export exit emergency-exit)
+
+  (import (scheme base) (stak base))
 
   (begin
     (define exit-success (data-rib procedure-type #f (cons 0 '())))


### PR DESCRIPTION
```
> hyperfine -w 5 'target/release/stak ~/baz.scm' '~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm'
Benchmark 1: target/release/stak ~/baz.scm
  Time (mean ± σ):      2.483 s ±  0.030 s    [User: 2.468 s, System: 0.003 s]
  Range (min … max):    2.444 s …  2.536 s    10 runs

Benchmark 2: ~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm
  Time (mean ± σ):      2.716 s ±  0.027 s    [User: 2.698 s, System: 0.002 s]
  Range (min … max):    2.688 s …  2.777 s    10 runs

Summary
  target/release/stak ~/baz.scm ran
    1.09 ± 0.02 times faster than ~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm
```