### PR TITLE
Remove OOM error from `Result`

### DIFF
--- a/primitive/src/small.rs
+++ b/primitive/src/small.rs
@@ -44,11 +44,9 @@ impl<T: Device> SmallPrimitiveSet<T> {
         vm.set_top(vm.boolean(operate(x.to_i64(), y.to_i64())).into());
     }
 
-    fn rib(vm: &mut Vm<Self>, r#type: u8, car: Value, cdr: Value) -> Result<(), Error> {
-        let rib = vm.allocate(car.set_tag(r#type), cdr)?;
+    fn rib(vm: &mut Vm<Self>, r#type: u8, car: Value, cdr: Value) {
+        let rib = vm.allocate(car.set_tag(r#type), cdr);
         vm.set_top(rib.into());
-
-        Ok(())
     }
 
     fn set_field<'a>(vm: &mut Vm<'a, Self>, set_field: fn(&mut Vm<'a, Self>, Value, Value)) {
@@ -116,12 +114,12 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
                     r#type.assume_number().to_i64() as u8,
                     car,
                     cdr.set_tag(tag.assume_number().to_i64() as u8),
-                )?;
+                );
             }
             Primitive::CONS => {
                 let [car, cdr] = Self::pop_arguments::<2>(vm);
 
-                Self::rib(vm, Type::Pair as u8, car, cdr)?;
+                Self::rib(vm, Type::Pair as u8, car, cdr);
             }
             Primitive::CLOSE => {
                 Self::rib(
@@ -129,7 +127,7 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
                     Type::Procedure as u8,
                     vm.cdr(vm.stack()),
                     vm.cdr_value(vm.top()),
-                )?;
+                );
             }
             Primitive::IS_RIB => {
                 Self::operate_top(vm, |vm, value| vm.boolean(value.is_cons()).into())
@@ -160,7 +158,7 @@ impl<T: Device> PrimitiveSet for SmallPrimitiveSet<T> {
                     Number::new(byte as i64).into()
                 } else {
                     vm.boolean(false).into()
-                })?;
+                });
             }
             Primitive::WRITE => Self::write(vm, Device::write, Error::WriteOutput)?,
             Primitive::WRITE_ERROR => Self::write(vm, Device::write_error, Error::WriteError)?,


### PR DESCRIPTION
It's not really faster!

```
> hyperfine -w 5 'target/release/stak ~/baz.scm' '~/worktree/7a1181edfad9f3e5/target/release/stak ~/baz.scm'
Benchmark 1: target/release/stak ~/baz.scm
  Time (mean ± σ):      2.278 s ±  0.046 s    [User: 2.248 s, System: 0.002 s]
  Range (min … max):    2.212 s …  2.346 s    10 runs

Benchmark 2: ~/worktree/7a1181edfad9f3e5/target/release/stak ~/baz.scm
  Time (mean ± σ):      2.273 s ±  0.018 s    [User: 2.259 s, System: 0.002 s]
  Range (min … max):    2.258 s …  2.320 s    10 runs

Summary
  ~/worktree/7a1181edfad9f3e5/target/release/stak ~/baz.scm ran
    1.00 ± 0.02 times faster than target/release/stak ~/baz.scm
```