### PR TITLE
Optimize pattern matching

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -567,7 +567,7 @@
                (resolve-denotation (rule-context-use-context context) expression)
                (resolve-denotation (rule-context-definition-context context) pattern))
         (raise #f))
-      '())
+      matches)
 
     ((symbol? pattern)
       (list (cons pattern expression)))

--- a/compile.scm
+++ b/compile.scm
@@ -585,7 +585,13 @@
               (match (cddr pattern) (list-tail expression length) matches))))
 
         ((pair? expression)
-          (match (car pattern) (car expression) (match (cdr pattern) (cdr expression) matches)))
+          (match
+            (car pattern)
+            (car expression)
+            (match
+              (cdr pattern)
+              (cdr expression)
+              matches)))
 
         (else
           (raise #f))))

--- a/compile.scm
+++ b/compile.scm
@@ -597,7 +597,7 @@
           (raise #f))))
 
     ((equal? pattern expression)
-      '())
+      matches)
 
     (else
       (raise #f))))

--- a/compile.scm
+++ b/compile.scm
@@ -570,7 +570,7 @@
       matches)
 
     ((symbol? pattern)
-      (list (cons pattern expression)))
+      (cons (cons pattern expression) matches))
 
     ((pair? pattern)
       (cond


### PR DESCRIPTION
This is actually slower...

```sh
> hyperfine -w 5 'target/release/stak ~/baz.scm' '~/worktree/41aeba4ff*/target/release/stak ~/baz.scm'
Benchmark 1: target/release/stak ~/baz.scm
  Time (mean ± σ):      1.461 s ±  0.008 s    [User: 1.453 s, System: 0.002 s]
  Range (min … max):    1.450 s …  1.470 s    10 runs

Benchmark 2: ~/worktree/41aeba4ff*/target/release/stak ~/baz.scm
  Time (mean ± σ):      1.428 s ±  0.019 s    [User: 1.418 s, System: 0.002 s]
  Range (min … max):    1.398 s …  1.455 s    10 runs

Summary
  ~/worktree/41aeba4ff*/target/release/stak ~/baz.scm ran
    1.02 ± 0.01 times faster than target/release/stak ~/baz.scm
```