### PR TITLE
Optimize denotation resolution

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -631,14 +631,14 @@
   (let-values (((transformer definition-context) (expand-outer-macro definition-context transformer)))
     (case (resolve-denotation definition-context (predicate transformer))
       (($$syntax-rules)
-        (let ((ellipsis (resolve-denotation definition-context (cadr transformer)))
-              (literals (caddr transformer))
-              (literal-denotations
-                (map
-                  (lambda (literal)
-                    (cons literal (resolve-denotation definition-context literal)))
-                  literals))
-              (rules (cdddr transformer)))
+        (let* ((ellipsis (resolve-denotation definition-context (cadr transformer)))
+               (literals (caddr transformer))
+               (literal-denotations
+                 (map
+                   (lambda (literal)
+                     (cons literal (resolve-denotation definition-context literal)))
+                   literals))
+               (rules (cdddr transformer)))
           (lambda (use-context expression)
             (let loop ((rules rules))
               (unless (pair? rules)


### PR DESCRIPTION
This is not really faster...

```sh
> hyperfine -w 5 'target/release/stak ~/baz.scm' '~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm'
Benchmark 1: target/release/stak ~/baz.scm
  Time (mean ± σ):      1.071 s ±  0.002 s    [User: 1.065 s, System: 0.001 s]
  Range (min … max):    1.066 s …  1.075 s    10 runs

Benchmark 2: ~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm
  Time (mean ± σ):      1.071 s ±  0.003 s    [User: 1.062 s, System: 0.001 s]
  Range (min … max):    1.068 s …  1.075 s    10 runs

Summary
  ~/src/github.com/raviqqe/stak/target/release/stak ~/baz.scm ran
    1.00 ± 0.00 times faster than target/release/stak ~/baz.scm
```