### PR TITLE
Separate global and local environments in macro expansion

### DIFF
--- a/compile.scm
+++ b/compile.scm
@@ -443,12 +443,13 @@
       (lambda (pair)
         (set-cdr! pair denotation)))
 
+    ((null? (macro-context-globals context))
+      (macro-context-set-globals! context (list (cons name denotation))))
+
     (else
-      (macro-context-set-globals!
-        context
-        (cons
-          (cons name denotation)
-          (macro-context-globals context))))))
+      (set-last-cdr!
+        (macro-context-globals context)
+        (list (cons name denotation))))))
 
 (define (macro-context-generate-id! context)
   (let ((id (macro-context-id context)))

--- a/compile.scm
+++ b/compile.scm
@@ -110,11 +110,6 @@
     (last-cdr (cdr xs))
     xs))
 
-(define (set-last-cdr! xs x)
-  (if (pair? (cdr xs))
-    (set-last-cdr! (cdr xs) x)
-    (set-cdr! xs x)))
-
 (define (filter f xs)
   (if (null? xs)
     '()
@@ -438,18 +433,19 @@
       (macro-context-set-global! context name denotation))))
 
 (define (macro-context-set-global! context name denotation)
-  (cond
-    ((assq name (macro-context-globals context)) =>
-      (lambda (pair)
-        (set-cdr! pair denotation)))
+  (let ((globals (macro-context-globals context)))
+    (cond
+      ((assq name globals) =>
+        (lambda (pair)
+          (set-cdr! pair denotation)))
 
-    ((null? (macro-context-globals context))
-      (macro-context-set-globals! context (list (cons name denotation))))
+      ((null? globals)
+        (macro-context-set-globals! context (list (cons name denotation))))
 
-    (else
-      (set-last-cdr!
-        (macro-context-globals context)
-        (list (cons name denotation))))))
+      (else
+        (set-cdr!
+          globals
+          (cons (cons name denotation) (cdr globals)))))))
 
 (define (macro-context-generate-id! context)
   (let ((id (macro-context-id context)))

--- a/compile.scm
+++ b/compile.scm
@@ -419,7 +419,7 @@
   (make-macro-context globals locals id)
   macro-context?
   (globals macro-context-globals macro-context-set-globals!)
-  (locals macro-context-locals macro-context-set-locals!)
+  (locals macro-context-locals)
   (id macro-context-id macro-context-set-id!))
 
 (define (macro-context-append context pairs)

--- a/compile.scm
+++ b/compile.scm
@@ -733,7 +733,7 @@
 
           (($$define)
             (let ((name (cadr expression)))
-              (macro-context-set-global! context name name)
+              (macro-context-set! context name name)
               (expand (cons '$$set! (cdr expression)))))
 
           (($$define-syntax)

--- a/compile.scm
+++ b/compile.scm
@@ -425,12 +425,15 @@
 
 (define (macro-context-set! context name denotation)
   (cond
-    ((assq name (macro-context-locals context)) =>
+    ((or
+        (assq name (macro-context-locals context))
+        (assq name (macro-context-globals context)))
+      =>
       (lambda (pair)
         (set-cdr! pair denotation)))
 
     (else
-      (macro-context-set-global! context name denotation))))
+      #f)))
 
 (define (macro-context-set-global! context name denotation)
   (let ((globals (macro-context-globals context)))


### PR DESCRIPTION
This is slower.

```
> hyperfine -w 5 'target/release/stak ~/baz.scm' '~/worktree/7a1181edf*/target/release/stak ~/baz.scm'
Benchmark 1: target/release/stak ~/baz.scm
  Time (mean ± σ):      1.275 s ±  0.039 s    [User: 1.261 s, System: 0.002 s]
  Range (min … max):    1.240 s …  1.337 s    10 runs

Benchmark 2: ~/worktree/7a1181edf*/target/release/stak ~/baz.scm
  Time (mean ± σ):      1.218 s ±  0.009 s    [User: 1.208 s, System: 0.001 s]
  Range (min … max):    1.209 s …  1.240 s    10 runs

Summary
  ~/worktree/7a1181edf*/target/release/stak ~/baz.scm ran
    1.05 ± 0.03 times faster than target/release/stak ~/baz.scm
```