### PR TITLE
Python as reference in benchmarks

### DIFF
--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -32,6 +32,7 @@ for file in $(ls */main.scm | sort | grep $filter); do
   base=${file%.scm}
 
   scripts="stak $file,mstak $file,stak-interpret $base.bc,mstak-interpret $base.bc,chibi-scheme $file,gosh $file,guile $file"
+  reference=
 
   if [ -r $base.py ]; then
     reference="python3 $base.py"

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -34,8 +34,14 @@ for file in $(ls */main.scm | sort | grep $filter); do
   scripts="stak $file,mstak $file,stak-interpret $base.bc,mstak-interpret $base.bc,chibi-scheme $file,gosh $file,guile $file"
 
   if [ -r $base.py ]; then
-    scripts="$scripts,python3 $base.py"
+    reference="python3 $base.py"
   fi
 
-  hyperfine -N --sort command --input ../../compile.scm -L script "$scripts" "{script}"
+  hyperfine \
+    -N \
+    --sort command \
+    --input ../../compile.scm \
+    ${reference:+--reference "$reference"} \
+    -L script "$scripts" \
+    "{script}"
 done

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -40,7 +40,6 @@ for file in $(ls */main.scm | sort | grep $filter); do
 
   hyperfine \
     -N \
-    --sort command \
     --input ../../compile.scm \
     ${reference:+--reference "$reference"} \
     -L script "$scripts" \


### PR DESCRIPTION
~~Blocked by https://github.com/sharkdp/hyperfine/issues/811~~ 

We ended up using summary tables without `--sort command` option for now.