### PR TITLE
Fix pending input ordering for peek operations

### DIFF
--- a/features/types/port.feature
+++ b/features/types/port.feature
@@ -84,6 +84,47 @@ Feature: Port
       | (open-output-file "foo.txt") |
       | (open-output-string)         |
 
+  @stak
+  Scenario Outline: Preserve pending input order after peeking
+    Given a file named "main.scm" with:
+      """scheme
+      (import (scheme base))
+
+      (define port (open-input-string "<input>"))
+      (peek-char port)
+      (peek-u8 port)
+      (write-u8 (if (= (read-u8 port) <first-byte>) 65 66))
+      """
+    When I successfully run `stak main.scm`
+    Then the stdout should contain exactly "A"
+
+    Examples:
+      | input | first-byte |
+      | éx    | 195        |
+      | 😄x    | 240        |
+
+  @stak
+  Scenario: Preserve pending input order when peeking a character
+    Given a file named "main.scm" with:
+      """scheme
+      (import (scheme base) (stak io))
+
+      (define port
+        (make-port
+          (lambda () #f)
+          #f
+          #f
+          (lambda () #f)
+          '(195 169 120)))
+      (peek-char port)
+      (for-each
+        (lambda (expected)
+          (write-u8 (if (= (read-u8 port) expected) 65 66)))
+        '(195 169 120))
+      """
+    When I successfully run `stak main.scm`
+    Then the stdout should contain exactly "AAA"
+
   @gauche @guile @stak
   Scenario Outline: Read from a string port
     Given a file named "main.scm" with:

--- a/prelude.scm
+++ b/prelude.scm
@@ -2190,7 +2190,7 @@
     (define (peek-u8 . rest)
       (let* ((port (get-input-port rest))
              (x (read-u8 port)))
-        (port-set-data! port (append (port-data port) (list x)))
+        (port-set-data! port (cons x (port-data port)))
         x))
 
     (define (u8-ready? . rest)
@@ -2255,7 +2255,7 @@
         (if (null? bytes)
           (eof-object)
           (begin
-            (port-set-data! port (append (port-data port) bytes))
+            (port-set-data! port (append bytes (port-data port)))
             (parse-char-bytes bytes)))))
 
     (define (char-ready? . rest)

--- a/snapshots/bench/src/eval/main.txt
+++ b/snapshots/bench/src/eval/main.txt
@@ -2867,11 +2867,10 @@ constant procedure 0 #t
   get 0
   call 1 #f read-u8
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
-  call 1 #f list
-  call 2 #f append
+  call 2 #f cons
   call 2 #f ||
   set 0
   get 0
@@ -3016,9 +3015,9 @@ constant procedure 0 #t
   if
     call 0 #f eof-object
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f append
   call 2 #f ||
   set 0

--- a/snapshots/bench/src/read/main.txt
+++ b/snapshots/bench/src/read/main.txt
@@ -1222,9 +1222,9 @@ constant procedure 0 #t
   if
     call 0 #f ||
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f ||
   call 2 #f ||
   set 0

--- a/snapshots/bench/src/write/main.txt
+++ b/snapshots/bench/src/write/main.txt
@@ -1533,9 +1533,9 @@ constant procedure 0 #t
   if
     call 0 #f ||
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f ||
   call 2 #f ||
   set 0

--- a/snapshots/cmd/decode/src/main.txt
+++ b/snapshots/cmd/decode/src/main.txt
@@ -1128,9 +1128,8 @@ constant procedure 0 #t
   get 0
   call 1 #f ||
   get 1
-  get 2
-  call 1 #f ||
-  get 2
+  get 1
+  get 3
   call 1 #f ||
   call 2 #f ||
   call 2 #f ||

--- a/snapshots/compile-unicode.txt
+++ b/snapshots/compile-unicode.txt
@@ -1690,9 +1690,9 @@ constant procedure 0 #t
   if
     call 0 #f ||
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f ||
   call 2 #f ||
   set 0

--- a/snapshots/compile.txt
+++ b/snapshots/compile.txt
@@ -2867,11 +2867,10 @@ constant procedure 0 #t
   get 0
   call 1 #f read-u8
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
-  call 1 #f list
-  call 2 #f append
+  call 2 #f cons
   call 2 #f ||
   set 0
   get 0
@@ -3016,9 +3015,9 @@ constant procedure 0 #t
   if
     call 0 #f eof-object
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f append
   call 2 #f ||
   set 0

--- a/snapshots/examples/fibonacci.txt
+++ b/snapshots/examples/fibonacci.txt
@@ -1533,9 +1533,9 @@ constant procedure 0 #t
   if
     call 0 #f ||
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f ||
   call 2 #f ||
   set 0

--- a/snapshots/examples/hot-reload/src/handler.txt
+++ b/snapshots/examples/hot-reload/src/handler.txt
@@ -1545,9 +1545,9 @@ constant procedure 0 #t
   if
     call 0 #f ||
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f ||
   call 2 #f ||
   set 0

--- a/snapshots/repl.txt
+++ b/snapshots/repl.txt
@@ -2867,11 +2867,10 @@ constant procedure 0 #t
   get 0
   call 1 #f read-u8
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
-  call 1 #f list
-  call 2 #f append
+  call 2 #f cons
   call 2 #f ||
   set 0
   get 0
@@ -3016,9 +3015,9 @@ constant procedure 0 #t
   if
     call 0 #f eof-object
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f append
   call 2 #f ||
   set 0

--- a/snapshots/run.txt
+++ b/snapshots/run.txt
@@ -2867,11 +2867,10 @@ constant procedure 0 #t
   get 0
   call 1 #f read-u8
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
-  call 1 #f list
-  call 2 #f append
+  call 2 #f cons
   call 2 #f ||
   set 0
   get 0
@@ -3016,9 +3015,9 @@ constant procedure 0 #t
   if
     call 0 #f eof-object
   get 1
-  get 2
+  get 1
+  get 3
   call 1 #f ||
-  get 2
   call 2 #f append
   call 2 #f ||
   set 0


### PR DESCRIPTION
## Summary

`peek-u8` and `peek-char` restore consumed input into a FIFO pending buffer. Appending peeked bytes to the back could rotate pending input and return the wrong byte after peeking.

- Prepend a peeked byte in `peek-u8`.
- Prepend the complete multibyte sequence in `peek-char` while preserving byte order.
- Add regressions for two- and four-byte UTF-8 input, plus a pre-buffered suffix.

## Tests

- `STAK_HOST= tools/integration_test.sh -i stak-tools -t '@stak' features/types/port.feature`\n- `cargo test -p stak-file -p stak-vm --locked`