### PR TITLE
Build Chibi Scheme against musl on Linux

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -86,10 +86,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-scheme
-      - if: matrix.type == 'binary'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+      - run: sudo apt-get install -y musl-tools
       - run: echo type=${{ matrix.type }}_size >> ${{ github.env }}
       - run: tools/${{ env.type }}_bench.sh
       # TODO Use `stak`.

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -86,6 +86,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-scheme
+      - if: matrix.type == 'binary'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
       - run: echo type=${{ matrix.type }}_size >> ${{ github.env }}
       - run: tools/${{ env.type }}_bench.sh
       # TODO Use `stak`.

--- a/tools/binary_size_bench.sh
+++ b/tools/binary_size_bench.sh
@@ -57,11 +57,17 @@ build_stak() (
 cd $(dirname $0)/..
 mkdir -p tmp
 
+compiler=cc
+
 if [ $(uname) = Linux ]; then
   target=$(uname -m)-unknown-linux-musl
+  # Chibi Scheme links a C standard library statically only on Linux. So build
+  # it against musl to measure its size on the same footing as the Rust
+  # binaries.
+  compiler=musl-gcc
 fi
 
-build_chibi
+CC=$compiler build_chibi
 build_tr7
 build_stak $target
 

--- a/tools/binary_size_bench.sh
+++ b/tools/binary_size_bench.sh
@@ -60,6 +60,7 @@ mkdir -p tmp
 if [ $(uname) = Linux ]; then
   target=$(uname -m)-unknown-linux-musl
   export CC=musl-gcc
+  export CFLAGS=-static
 fi
 
 build_chibi

--- a/tools/binary_size_bench.sh
+++ b/tools/binary_size_bench.sh
@@ -57,17 +57,12 @@ build_stak() (
 cd $(dirname $0)/..
 mkdir -p tmp
 
-compiler=cc
-
 if [ $(uname) = Linux ]; then
   target=$(uname -m)-unknown-linux-musl
-  # Chibi Scheme links a C standard library statically only on Linux. So build
-  # it against musl to measure its size on the same footing as the Rust
-  # binaries.
-  compiler=musl-gcc
+  export CC=musl-gcc
 fi
 
-CC=$compiler build_chibi
+build_chibi
 build_tr7
 build_stak $target
 


### PR DESCRIPTION
Chibi Scheme's static build embeds a C standard library only on Linux,
where glibc accounts for about 900 KB out of its 1.1 MB binary. Build it
with musl instead so that its size is comparable to the Rust binaries,
which are already built for musl targets.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U9kSRRj2tKxqPkxTKmvszg
